### PR TITLE
Hf 10 lines should lose health when overloaded

### DIFF
--- a/src/engine/engine.py
+++ b/src/engine/engine.py
@@ -106,9 +106,8 @@ class Engine:
                         message=text,
                     )
                 )
-            new_game_state, msgs_melted_icecream = Referee.melt_ice_creams(new_game_state)
-            new_game_state, msgs_worn_assets = Referee.wear_non_freezer_assets(new_game_state)
-            msgs.extend(msgs_melted_icecream + msgs_worn_assets)
+            new_game_state, all_referee_msgs = Referee.apply_rules_after_market_coupling(new_game_state)
+            msgs.extend(all_referee_msgs)
 
             return new_game_state, msgs
 

--- a/src/engine/referee.py
+++ b/src/engine/referee.py
@@ -41,29 +41,6 @@ class Referee:
         raise NotImplementedError()
 
     # AFTER MARKET COUPLING
-    @classmethod
-    def apply_rules_after_market_coupling(cls, gs: GameState) -> tuple[GameState, list[GameToPlayerMessage]]:
-        """
-        Apply the rules that are enforced after the market coupling phase.
-        :param gs: The current game state
-        :return: A tuple containing the new game state and a list of messages to be sent to players
-        """
-        assert gs.market_coupling_result is not None, "Market coupling result must be available to apply rules."
-        assert gs.phase == Phase.DA_AUCTION, "Rules can only be applied at the end of DA auction phase."
-
-        new_gs = gs
-        msgs: list[GameToPlayerMessage] = []
-
-        new_gs, ice_cream_msgs = cls.melt_ice_creams(new_gs)
-        msgs.extend(ice_cream_msgs)
-
-        new_gs, transmission_msgs = cls.wear_congested_transmission(new_gs)
-        msgs.extend(transmission_msgs)
-
-        new_gs, asset_msgs = cls.wear_non_freezer_assets(new_gs)
-        msgs.extend(asset_msgs)
-
-        return new_gs, msgs
 
     @staticmethod
     def melt_ice_creams(gs: GameState) -> tuple[GameState, list[IceCreamMeltedMessage]]:
@@ -98,7 +75,9 @@ class Referee:
     @staticmethod
     def wear_congested_transmission(gs: GameState) -> tuple[GameState, list[TransmissionWornMessage]]:
 
-        def generate_worn_transmission_messages(new_gs: GameState, transmission_ids: list[TransmissionId]) -> list[TransmissionWornMessage]:
+        def generate_worn_transmission_messages(
+            new_gs: GameState, transmission_ids: list[TransmissionId]
+        ) -> list[TransmissionWornMessage]:
             return [
                 TransmissionWornMessage(
                     player_id=new_gs.transmission[transmission_id].owner_player,
@@ -107,6 +86,7 @@ class Referee:
                 )
                 for transmission_id in transmission_ids
             ]
+
         transmission_repo = gs.transmission
         congested_transmissions: list[TransmissionId] = []
         flows = gs.market_coupling_result.transmission_flows

--- a/src/engine/referee.py
+++ b/src/engine/referee.py
@@ -41,6 +41,29 @@ class Referee:
         raise NotImplementedError()
 
     # AFTER MARKET COUPLING
+    @classmethod
+    def apply_rules_after_market_coupling(cls, gs: GameState) -> tuple[GameState, list[GameToPlayerMessage]]:
+        """
+        Apply the rules that are enforced after the market coupling phase.
+        :param gs: The current game state
+        :return: A tuple containing the new game state and a list of messages to be sent to players
+        """
+        assert gs.market_coupling_result is not None, "Market coupling result must be available to apply rules."
+        assert gs.phase == Phase.DA_AUCTION, "Rules can only be applied at the end of DA auction phase."
+
+        new_gs = gs
+        msgs: list[GameToPlayerMessage] = []
+
+        new_gs, ice_cream_msgs = cls.melt_ice_creams(new_gs)
+        msgs.extend(ice_cream_msgs)
+
+        new_gs, transmission_msgs = cls.wear_congested_transmission(new_gs)
+        msgs.extend(transmission_msgs)
+
+        new_gs, asset_msgs = cls.wear_non_freezer_assets(new_gs)
+        msgs.extend(asset_msgs)
+
+        return new_gs, msgs
 
     @staticmethod
     def melt_ice_creams(gs: GameState) -> tuple[GameState, list[IceCreamMeltedMessage]]:

--- a/src/engine/referee.py
+++ b/src/engine/referee.py
@@ -1,10 +1,13 @@
 from dataclasses import replace
+import numpy as np
 
 from src.models.ids import AssetId, TransmissionId
 from src.models.message import (
     GameUpdate,
     IceCreamMeltedMessage,
     AssetWornMessage,
+    TransmissionWornMessage,
+    GameToPlayerMessage,
 )  # , BuyAssetRequest, BuyAssetResponse, BuyTransmissionRequest, BuyTransmissionResponse, BuyResponse
 from src.models.game_state import GameState, Phase
 
@@ -40,13 +43,11 @@ class Referee:
     # AFTER MARKET COUPLING
 
     @staticmethod
-    def melt_ice_creams(gs: GameState) -> tuple[GameState, list[GameUpdate]]:
-        assert gs.market_coupling_result is not None, "Market coupling result must be available to melt ice creams."
-        assert gs.phase == Phase.DA_AUCTION, "Ice creams only melt at the end of the DA auction phase."
+    def melt_ice_creams(gs: GameState) -> tuple[GameState, list[IceCreamMeltedMessage]]:
 
         def generate_melted_ice_cream_messages(
             new_gs: GameState, asset_ids: list[AssetId]
-        ) -> list[IceCreamMeltedMessage | GameUpdate]:
+        ) -> list[IceCreamMeltedMessage]:
             return [
                 IceCreamMeltedMessage(
                     player_id=new_gs.assets[asset_id].owner_player,
@@ -72,13 +73,33 @@ class Referee:
         return new_gs, msgs
 
     @staticmethod
-    def wear_overloaded_transmission(gs: GameState) -> tuple[GameState, list[GameUpdate]]:
-        raise NotImplementedError()
+    def wear_congested_transmission(gs: GameState) -> tuple[GameState, list[TransmissionWornMessage]]:
+
+        def generate_worn_transmission_messages(new_gs: GameState, transmission_ids: list[TransmissionId]) -> list[TransmissionWornMessage]:
+            return [
+                TransmissionWornMessage(
+                    player_id=new_gs.transmission[transmission_id].owner_player,
+                    transmission_id=transmission_id,
+                    message=f"Transmission line {TransmissionId} has worn due to congestion, it can only withstand {new_gs.transmission[transmission_id].health} more congested periods.",
+                )
+                for transmission_id in transmission_ids
+            ]
+        transmission_repo = gs.transmission
+        congested_transmissions: list[TransmissionId] = []
+        flows = gs.market_coupling_result.transmission_flows
+
+        for transmission in transmission_repo:
+            if np.isclose(transmission.capacity, flows[transmission.id]):
+                transmission_repo = transmission_repo.wear_transmission(transmission_id=transmission.id)
+                congested_transmissions.append(transmission.id)
+
+        new_gs = replace(gs, transmission=transmission_repo)
+        msgs = generate_worn_transmission_messages(new_gs=new_gs, transmission_ids=congested_transmissions)
+
+        return new_gs, msgs
 
     @staticmethod
     def wear_non_freezer_assets(gs: GameState) -> tuple[GameState, list[AssetWornMessage]]:
-        assert gs.market_coupling_result is not None, "Market coupling result must be available to wear assets."
-        assert gs.phase == Phase.DA_AUCTION, "Assets only suffer wear at the end DA auction phase."
 
         def generate_worn_asset_messages(new_gs: GameState, asset_ids: list[AssetId]) -> list[AssetWornMessage]:
             return [

--- a/src/models/transmission.py
+++ b/src/models/transmission.py
@@ -87,6 +87,17 @@ class TransmissionRepo(LdcRepo[TransmissionInfo]):
         df.loc[transmission_id, "is_for_sale"] = False
         return self.update_frame(df)
 
+    def wear_transmission(self, transmission_id: TransmissionId) -> Self:
+        if self.df.loc[transmission_id, "health"] > 1:
+            df = self.df.copy()
+            df.loc[transmission_id, "health"] -= 1
+            return self.update_frame(df)
+        else:
+            df = self.df.copy()
+            df.loc[transmission_id, "health"] = 0
+            df.loc[transmission_id, "is_active"] = False
+            return self.update_frame(df)
+
     # DELETE
     def delete_for_player(self, player_id: PlayerId) -> Self:
         return self.drop_items({"owner_player": player_id})

--- a/tests/test_engine/test_referee.py
+++ b/tests/test_engine/test_referee.py
@@ -88,3 +88,16 @@ class TestReferee(TestCase):
             else:
                 self.assertFalse(new_game_state.transmission[transmission.id].is_active)
                 self.assertEqual(new_game_state.transmission[transmission.id].health, 0)
+
+    def test_apply_rules_after_market_coupling(self):
+        game_state, market_result = self.create_game_state_and_market_coupling_result()
+
+        new_game_state, update_msgs = Referee.apply_rules_after_market_coupling(game_state)
+        melt_ice_cream_msgs = [msg for msg in update_msgs if isinstance(msg, IceCreamMeltedMessage)]
+        wear_transmission_msgs = [msg for msg in update_msgs if isinstance(msg, TransmissionWornMessage)]
+        wear_asset_msgs = [msg for msg in update_msgs if isinstance(msg, AssetWornMessage)]
+
+        self.assertIsInstance(new_game_state, GameState)
+        self.assertGreater(len(melt_ice_cream_msgs), 0)
+        self.assertGreater(len(wear_transmission_msgs), 0)
+        self.assertGreater(len(wear_asset_msgs), 0)

--- a/tests/test_engine/test_referee.py
+++ b/tests/test_engine/test_referee.py
@@ -28,7 +28,7 @@ class TestReferee(TestCase):
             bus_repo=game_state.buses,
             asset_repo=game_state.assets,
             transmission_repo=game_state.transmission,
-            n_random_congested_transmissions=2
+            n_random_congested_transmissions=2,
         )
         game_state = replace(game_state, phase=Phase.DA_AUCTION, market_coupling_result=market_coupling_result)
 
@@ -88,16 +88,3 @@ class TestReferee(TestCase):
             else:
                 self.assertFalse(new_game_state.transmission[transmission.id].is_active)
                 self.assertEqual(new_game_state.transmission[transmission.id].health, 0)
-
-    def test_apply_rules_after_market_coupling(self):
-        game_state, market_result = self.create_game_state_and_market_coupling_result()
-
-        new_game_state, update_msgs = Referee.apply_rules_after_market_coupling(game_state)
-        melt_ice_cream_msgs = [msg for msg in update_msgs if isinstance(msg, IceCreamMeltedMessage)]
-        wear_transmission_msgs = [msg for msg in update_msgs if isinstance(msg, TransmissionWornMessage)]
-        wear_asset_msgs = [msg for msg in update_msgs if isinstance(msg, AssetWornMessage)]
-
-        self.assertIsInstance(new_game_state, GameState)
-        self.assertGreater(len(melt_ice_cream_msgs), 0)
-        self.assertGreater(len(wear_transmission_msgs), 0)
-        self.assertGreater(len(wear_asset_msgs), 0)

--- a/tests/utils/game_state_maker.py
+++ b/tests/utils/game_state_maker.py
@@ -15,7 +15,6 @@ from src.tools.random_choice import random_choice, random_choice_multi
 from tests.utils.repo_maker import PlayerRepoMaker, BusRepoMaker, AssetRepoMaker, TransmissionRepoMaker
 
 
-
 class MarketResultMaker:
     @staticmethod
     def make_quick(
@@ -41,7 +40,9 @@ class MarketResultMaker:
 
         tx_columns = pd.Index([t.as_int() for t in transmission_repo.transmission_ids], name="Line")
         tx_data = np.random.rand(n_timesteps, len(tx_columns))
-        congested_ids = random_choice_multi(transmission_repo.transmission_ids, size=n_random_congested_transmissions, replace=False)
+        congested_ids = random_choice_multi(
+            transmission_repo.transmission_ids, size=n_random_congested_transmissions, replace=False
+        )
         for id in congested_ids:
             tx_data[:, id] = transmission_repo[id].capacity
         transmission_flows = pd.DataFrame(index=market_time_units, columns=tx_columns, data=tx_data)

--- a/tests/utils/game_state_maker.py
+++ b/tests/utils/game_state_maker.py
@@ -11,8 +11,9 @@ from src.models.ids import GameId
 from src.models.market_coupling_result import MarketCouplingResult
 from src.models.player import PlayerRepo
 from src.models.transmission import TransmissionRepo
-from src.tools.random_choice import random_choice
+from src.tools.random_choice import random_choice, random_choice_multi
 from tests.utils.repo_maker import PlayerRepoMaker, BusRepoMaker, AssetRepoMaker, TransmissionRepoMaker
+
 
 
 class MarketResultMaker:
@@ -22,6 +23,7 @@ class MarketResultMaker:
         bus_repo: Optional[BusRepo] = None,
         asset_repo: Optional[AssetRepo] = None,
         transmission_repo: Optional[TransmissionRepo] = None,
+        n_random_congested_transmissions: int = 0,
         n_timesteps: int = 1,
     ) -> MarketCouplingResult:
         market_time_units = pd.Index([k for k in range(n_timesteps)], name="time")
@@ -39,6 +41,9 @@ class MarketResultMaker:
 
         tx_columns = pd.Index([t.as_int() for t in transmission_repo.transmission_ids], name="Line")
         tx_data = np.random.rand(n_timesteps, len(tx_columns))
+        congested_ids = random_choice_multi(transmission_repo.transmission_ids, size=n_random_congested_transmissions, replace=False)
+        for id in congested_ids:
+            tx_data[:, id] = transmission_repo[id].capacity
         transmission_flows = pd.DataFrame(index=market_time_units, columns=tx_columns, data=tx_data)
 
         asset_columns = pd.Index([a.as_int() for a in asset_repo.asset_ids], name="Asset")


### PR DESCRIPTION
* wear transmission due to congestion (~overloading since optimization problem will never allow overloading...)
   * This is strange though, this basically means that you are only eligible for a `health` number of congestion revenues. And you gotta, therefore, figure out what they should be (and how to achieve them) to breakeven before the lifespan of the line. It is an interesting strategic choice when investing in transmission.
* improve referee workflow (his syndicate forced us)
* some other small cleanups