### PR TITLE
Hf 70 add controls to activate deactivate lines and assets

### DIFF
--- a/back_end/src/engine/engine.py
+++ b/back_end/src/engine/engine.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast
+from typing import cast
 
 import polars as pl
 
@@ -9,15 +9,13 @@ from src.models.game_state import GameState, Phase
 from src.models.ids import AssetId, Round, TransmissionId
 from src.models.market_coupling_result import MarketCouplingResult
 from src.models.message import (
+    Ack,
+    ActivationUpdateRequest,
     AuctionClearedMessage,
     BuyRequest,
     ConcludePhase,
     EndTurn,
     Message,
-    OperateAssetRequest,
-    OperateAssetResponse,
-    OperateLineRequest,
-    OperateLineResponse,
     PlayerNotInTurn,
     PlayerToGameMessage,
     ToGameMessage,
@@ -26,6 +24,7 @@ from src.models.message import (
     UpdateBidRequest,
     UpdateBidResponse,
 )
+from src.models.pending_state import PendingState
 
 
 class Engine:
@@ -51,10 +50,8 @@ class Engine:
                 return cls.handle_update_bid_message(game_state=game_state, msg=msg)
             case UpdateBatchBidsRequest():
                 return cls.handle_update_batch_bid_message(game_state=game_state, msg=msg)
-            case OperateLineRequest():
-                return cls.handle_operate_line_message(game_state, msg)
-            case OperateAssetRequest():
-                return cls.handle_operate_asset_message(game_state, msg)
+            case ActivationUpdateRequest():
+                return cls.handle_activation_update_message(game_state, msg)
             case BuyRequest() if isinstance(msg.purchase_id, AssetId):
                 return cls.handle_buy_asset_message(game_state, msg)  # type: ignore
             case BuyRequest() if isinstance(msg.purchase_id, TransmissionId):
@@ -225,110 +222,15 @@ class Engine:
         return new_game_state, [response]
 
     @classmethod
-    def handle_operate_line_message(
+    def handle_activation_update_message(
         cls,
         game_state: GameState,
-        msg: OperateLineRequest,
+        msg: ActivationUpdateRequest,
     ) -> tuple[GameState, list[Message]]:
-        def make_response(
-            result: Literal["success", "no_change", "failure"],
-            text: str,
-            new_game_state: GameState | None = None,
-        ) -> tuple[GameState, list[Message]]:
-            if new_game_state is None:
-                new_game_state = game_state
-            response = OperateLineResponse(game_id=game_state.game_id, player_id=msg.player_id, request=msg, result=result, message=text)
-            return new_game_state, [response]
-
-        if game_state.phase != Phase.SNEAKY_TRICKS:
-            return make_response(
-                result="failure",
-                text=f"You can only operate lines during the {Phase.SNEAKY_TRICKS.nice_name} phase.",
-            )
-
-        if msg.transmission_id not in game_state.transmission.transmission_ids:
-            return make_response(result="failure", text="Transmission does not exist.")
-
-        line = game_state.transmission[msg.transmission_id]
-        if line.owner_player != msg.player_id:
-            return make_response(result="failure", text="Transmission does not belong to this player.")
-
-        if msg.action == "open":
-            if line.is_open:
-                return make_response(result="no_change", text="Transmission line is already open.")
-            else:
-                new_state = game_state.update(game_state.transmission.open_line(line.id))
-                return make_response(
-                    result="success",
-                    text="Transmission line opened successfully.",
-                    new_game_state=new_state,
-                )
-
-        assert msg.action == "close"
-        if line.is_closed:
-            return make_response(result="no_change", text="Transmission line is already closed.")
-
-        new_state = game_state.update(game_state.transmission.close_line(line.id))
-        return make_response(
-            result="success",
-            text="Transmission line closed successfully.",
-            new_game_state=new_state,
-        )
-
-    @classmethod
-    def handle_operate_asset_message(
-        cls,
-        game_state: GameState,
-        msg: OperateAssetRequest,
-    ) -> tuple[GameState, list[Message]]:
-        def make_response(
-            result: Literal["success", "no_change", "failure"],
-            text: str,
-            new_game_state: GameState | None = None,
-        ) -> tuple[GameState, list[Message]]:
-            if new_game_state is None:
-                new_game_state = game_state
-            response = OperateAssetResponse(game_id=game_state.game_id, player_id=msg.player_id, request=msg, result=result, message=text)
-            return new_game_state, [response]
-
-        if game_state.phase != Phase.BIDDING:
-            return make_response(
-                result="failure",
-                text=f"You can only operate assets during the {Phase.BIDDING.nice_name} phase.",
-            )
-
-        if msg.asset_id not in game_state.assets.asset_ids:
-            return make_response(result="failure", text="Asset does not exist.")
-
-        asset = game_state.assets[msg.asset_id]
-        if asset.owner_player != msg.player_id:
-            return make_response(result="failure", text="Asset does not belong to this player.")
-
-        if msg.action == "shutdown":
-            if not asset.is_active:
-                return make_response(result="no_change", text="Asset is already off.")
-            else:
-                new_state = game_state.update(game_state.assets.deactivate(asset.id))
-                return make_response(
-                    result="success",
-                    text="Asset successfully deactivated.",
-                    new_game_state=new_state,
-                )
-
-        assert msg.action == "startup"
-        player = game_state.players[msg.player_id]
-        if player.money < 0 and asset.asset_type.name == "LOAD":
-            return make_response(result="failure", text="Player cannot activate loads when their balance is negative.")
-
-        if asset.is_active:
-            return make_response(result="no_change", text="Asset is already running.")
-
-        new_state = game_state.update(game_state.assets.activate(asset.id))
-        return make_response(
-            result="success",
-            text="Asset successfully activated.",
-            new_game_state=new_state,
-        )
+        pending_state = game_state.pending_state.update(PendingState(line_activation=msg.line_activation, asset_activation=msg.asset_activation))
+        new_game_state = game_state.update(pending_state)
+        response = Ack(game_id=game_state.game_id, player_id=msg.player_id)
+        return new_game_state, [response]
 
     @classmethod
     def handle_end_turn_message(
@@ -344,6 +246,7 @@ class Engine:
 
         game_state = game_state.update(players)
         if game_state.players.are_all_players_finished():
+            game_state = game_state.commit_pending_state()
             return game_state, [ConcludePhase(game_id=game_state.game_id, phase=game_state.phase)]
         else:
             return game_state, []

--- a/back_end/src/models/assets.py
+++ b/back_end/src/models/assets.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from enum import IntEnum
 from functools import cached_property
+from types import MappingProxyType
 
 from randcraft import make_dirac, make_uniform
 from randcraft.random_variable import RandomVariable
@@ -142,19 +143,28 @@ class AssetRepo(LdcRepo[AssetInfo]):
         return self._decrease_health(asset_id)
 
     def deactivate(self, asset_id: AssetId) -> "AssetRepo":
-        df = self.df.copy()
+        df = self.df
         df.loc[asset_id, "is_active"] = False
         return self.update_frame(df)
 
     def activate(self, asset_id: AssetId) -> "AssetRepo":
-        df = self.df.copy()
+        df = self.df
         df.loc[asset_id, "is_active"] = True
         return self.update_frame(df)
 
     def batch_deactivate(self, asset_ids: list[AssetId]) -> "AssetRepo":
-        df = self.df.copy()
+        df = self.df
         df.loc[asset_ids, "is_active"] = False
         return self.update_frame(df)
+
+    def update_activations(self, activations: MappingProxyType[AssetId, bool]) -> "AssetRepo":
+        df = self.df
+        actives = [k for k, v in activations.items() if v]
+        inactives = [k for k, v in activations.items() if not v]
+        df.loc[actives, "is_active"] = True
+        df.loc[inactives, "is_active"] = False
+        return self.update_frame(df)
+
 
     # DELETE
     def delete_for_player(self, player_id: PlayerId) -> "AssetRepo":

--- a/back_end/src/models/assets.py
+++ b/back_end/src/models/assets.py
@@ -83,6 +83,10 @@ class AssetRepo(LdcRepo[AssetInfo]):
         return self._filter({"is_freezer": True})
 
     @cached_property
+    def not_freezers(self) -> "AssetRepo":
+        return self._filter({"is_freezer": False})
+
+    @cached_property
     def only_loads(self) -> "AssetRepo":
         return self._filter({"asset_type": AssetType.LOAD})
 

--- a/back_end/src/models/assets.py
+++ b/back_end/src/models/assets.py
@@ -108,28 +108,28 @@ class AssetRepo(LdcRepo[AssetInfo]):
 
     # UPDATE
     def change_owner(self, asset_id: AssetId, new_owner: PlayerId) -> "AssetRepo":
-        df = self.df.copy()
+        df = self.df
         df.loc[asset_id, "owner_player"] = simplify_type(new_owner)
         df.loc[asset_id, "is_for_sale"] = False
         return self.update_frame(df)
 
     def update_bid_price(self, asset_id: AssetId, bid_price: float) -> "AssetRepo":
-        df = self.df.copy()
+        df = self.df
         df.loc[asset_id, "bid_price"] = bid_price
         return self.update_frame(df)
 
     def batch_update_bid_price(self, asset_ids: list[AssetId], bid_prices: list[float]) -> "AssetRepo":
-        df = self.df.copy()
+        df = self.df
         df.loc[asset_ids, "bid_price"] = bid_prices
         return self.update_frame(df)
 
     def _decrease_health(self, asset_id: AssetId) -> "AssetRepo":
         if self.df.loc[asset_id, "health"] > 1:  # type: ignore
-            df = self.df.copy()
+            df = self.df
             df.loc[asset_id, "health"] -= 1  # type: ignore
             return self.update_frame(df)
         else:
-            df = self.df.copy()
+            df = self.df
             df.loc[asset_id, "health"] = 0
             df.loc[asset_id, "is_active"] = False
             return self.update_frame(df)

--- a/back_end/src/models/buses.py
+++ b/back_end/src/models/buses.py
@@ -1,9 +1,9 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from src.models.data.ldc_repo import LdcRepo
 from src.models.data.light_dc import LightDc
 from src.models.geometry import Point
-from src.models.ids import BusId, PlayerId
+from src.models.ids import BusId
 from src.tools.random_choice import random_choice, random_choice_multi
 
 
@@ -12,7 +12,6 @@ class Bus(LightDc):
     id: BusId
     x: float
     y: float
-    player_id: PlayerId = field(default_factory=PlayerId.get_npc)
     max_lines: int = 5
     max_assets: int = 5
 
@@ -43,24 +42,6 @@ class BusRepo(LdcRepo[Bus]):
     @property
     def bus_ids(self) -> list[BusId]:
         return [BusId(x) for x in self.df.index.tolist()]
-
-    @property
-    def npc_bus_ids(self) -> list[BusId]:
-        return self._filter({"player_id": PlayerId.get_npc()}).bus_ids
-
-    @property
-    def player_bus_ids(self) -> list[BusId]:
-        return self._filter(operator="not", condition={"player_id": PlayerId.get_npc()}).bus_ids
-
-    @property
-    def freezer_buses(self) -> list[Bus]:
-        return [self[b] for b in self.player_bus_ids]
-
-    def get_bus_for_player(self, player_id: PlayerId) -> Bus:
-        player_buses = self._filter({"player_id": player_id})
-        assert len(player_buses) == 1
-        return player_buses.as_objs()[0]
-
 
 class BusFullException(Exception):
     # You have to sit on the bus driver's lap

--- a/back_end/src/models/game_state.py
+++ b/back_end/src/models/game_state.py
@@ -140,7 +140,7 @@ class GameState:
     @classmethod
     @lru_cache(1)
     def get_type_to_attr_map(cls) -> dict[type[GameStateAttributes], str]:
-        attr_to_type: dict[str, type[GameStateAttributes]] = {f.name: f.type for f in fields(cls)}
+        attr_to_type: dict[str, type[GameStateAttributes]] = {f.name: f.type for f in fields(cls)}  # type: ignore
         attr_to_type["market_coupling_result"] = MarketCouplingResult
         type_to_attr: dict[type[GameStateAttributes], str] = {v: k for k, v in attr_to_type.items()}
         return type_to_attr

--- a/back_end/src/models/game_state.py
+++ b/back_end/src/models/game_state.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, fields, replace
 from enum import IntEnum
-from functools import cached_property
+from functools import cached_property, lru_cache
 from typing import Self
 
 from src.models.assets import AssetInfo, AssetRepo
@@ -8,6 +8,7 @@ from src.models.buses import BusFullException, BusRepo
 from src.models.game_settings import GameSettings
 from src.models.ids import BusId, GameId, PlayerId, Round
 from src.models.market_coupling_result import MarketCouplingResult, MarketCouplingSummary
+from src.models.pending_state import PendingState
 from src.models.player import PlayerRepo
 from src.models.transmission import TransmissionInfo, TransmissionRepo
 from src.tools.serialization import simplify_type, un_simplify_type
@@ -39,7 +40,7 @@ class Phase(IntEnum):
         return Phase(next_index)
 
 
-type GameStateAttributes = Phase | PlayerRepo | BusRepo | AssetRepo | TransmissionRepo | MarketCouplingResult | MarketCouplingSummary | Round
+type GameStateAttributes = Phase | PlayerRepo | BusRepo | AssetRepo | TransmissionRepo | MarketCouplingResult | MarketCouplingSummary | Round | PendingState
 
 
 @dataclass(frozen=True)
@@ -54,6 +55,7 @@ class GameState:
     market_coupling_result: MarketCouplingResult | None
     market_summary: MarketCouplingSummary | None = None
     game_round: Round = Round(1)
+    pending_state: PendingState = PendingState()
 
     def __post_init__(self) -> None:
         assert isinstance(self.game_round, Round), f"game_round must be of type Round. Got {type(self.game_round)}"
@@ -62,6 +64,11 @@ class GameState:
     @cached_property
     def current_players(self) -> list[PlayerId]:
         return self.players.get_currently_playing().player_ids
+
+    def commit_pending_state(self) -> Self:
+        assets = self.assets.update_activations(self.pending_state.asset_activation)
+        transmission = self.transmission.update_activations(self.pending_state.line_activation)
+        return self.update(assets, transmission, PendingState())
 
     def add_asset(self, asset: AssetInfo) -> Self:
         bus_id = asset.bus
@@ -107,17 +114,13 @@ class GameState:
                 raise ValueError(f"Cannot update {key} multiple times in one update call.")
             map_new_attributes[key] = attribute
 
-        # Create a mapping from type to field name using dataclass fields
-        attr_to_type: dict[str, type[GameStateAttributes]] = {f.name: f.type for f in fields(self)}  # type: ignore
-        attr_to_type["market_coupling_result"] = MarketCouplingResult  # type: ignore
-        type_to_attr: dict[type[GameStateAttributes], str] = {v: k for k, v in attr_to_type.items()}
-
         for k, attr in enumerate(new_attributes):
-            attr_name = type_to_attr.get(type(attr), None)
+            attr_name = self.get_type_to_attr_map().get(type(attr), None)
             assert attr_name is not None, f"Attribute in position {k} of with value {attr} of {type(attr)} is not a valid GameState attribute."
             append_to_map(attr_name, attr)
 
         return replace(self, **map_new_attributes)  # type: ignore[arg-type]
+
 
     def to_simple_dict(self) -> dict:
         return {
@@ -131,7 +134,17 @@ class GameState:
             "market_coupling_result": (self.market_coupling_result.to_simple_dict() if self.market_coupling_result else None),
             "market_summary": (self.market_summary.to_simple_dict() if self.market_summary else None),
             "game_round": self.game_round,
+            "pending_state": self.pending_state.to_simple_dict()
         }
+
+    @classmethod
+    @lru_cache(1)
+    def get_type_to_attr_map(cls) -> dict[type[GameStateAttributes], str]:
+        attr_to_type: dict[str, type[GameStateAttributes]] = {f.name: f.type for f in fields(cls)}
+        attr_to_type["market_coupling_result"] = MarketCouplingResult
+        type_to_attr: dict[type[GameStateAttributes], str] = {v: k for k, v in attr_to_type.items()}
+        return type_to_attr
+
 
     @classmethod
     def from_simple_dict(cls, simple_dict: dict) -> Self:
@@ -146,4 +159,5 @@ class GameState:
             market_coupling_result=(MarketCouplingResult.from_simple_dict(simple_dict["market_coupling_result"]) if simple_dict.get("market_coupling_result") else None),
             market_summary=(MarketCouplingSummary.from_simple_dict(simple_dict["market_summary"]) if simple_dict.get("market_summary") else None),
             game_round=Round(simple_dict["game_round"]),
+            pending_state=PendingState.from_simple_dict(simple_dict["pending_state"])
         )

--- a/back_end/src/models/message.py
+++ b/back_end/src/models/message.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Literal, TypeVar
+from typing import TypeVar
 
 from src.models.assets import AssetId
 from src.models.game_state import GameState, Phase
@@ -89,6 +89,10 @@ class UpdateBidResponse(GameToPlayerMessage):
     success: bool
     asset_id: AssetId
 
+@dataclass(frozen=True)
+class Ack(GameToPlayerMessage):
+    message: str = "👍"
+
 
 @dataclass(frozen=True)
 class UpdateBidRequest(PlayerToGameMessage):
@@ -143,29 +147,14 @@ class BuyRequest[T_Id](PlayerToGameMessage):
             message=message,
         )
 
-
 @dataclass(frozen=True)
-class OperateLineRequest(PlayerToGameMessage):
-    transmission_id: TransmissionId
-    action: Literal["open", "close"]
+class ActivationUpdateRequest(PlayerToGameMessage):
+    """
+    Describes the activation state of all lines and assets (if they are active or not)
+    """
 
-
-@dataclass(frozen=True)
-class OperateLineResponse(GameToPlayerMessage):
-    request: OperateLineRequest
-    result: Literal["success", "no_change", "failure"]
-
-
-@dataclass(frozen=True)
-class OperateAssetRequest(PlayerToGameMessage):
-    asset_id: AssetId
-    action: Literal["shutdown", "startup"]
-
-
-@dataclass(frozen=True)
-class OperateAssetResponse(GameToPlayerMessage):
-    request: OperateAssetRequest
-    result: Literal["success", "no_change", "failure"]
+    line_activation: MappingProxyType[TransmissionId, bool]
+    asset_activation: MappingProxyType[AssetId, bool]
 
 
 @dataclass(frozen=True)

--- a/back_end/src/models/pending_state.py
+++ b/back_end/src/models/pending_state.py
@@ -3,7 +3,6 @@ from types import MappingProxyType
 
 from src.models.ids import AssetId, TransmissionId
 
-_empty_mapping = field(default_factory=lambda: MappingProxyType({}))
 
 @dataclass(frozen=True)
 class PendingState:
@@ -31,7 +30,7 @@ class PendingState:
 
     @staticmethod
     def join_dicts[T, U](old: MappingProxyType[T, U], new: MappingProxyType[T, U]) -> MappingProxyType[T, U]:
-        new_dict = {}
+        new_dict: dict[T, U] = {}
         for d in [old, new]:
             new_dict.update(d)
         return MappingProxyType(new_dict)

--- a/back_end/src/models/pending_state.py
+++ b/back_end/src/models/pending_state.py
@@ -18,15 +18,15 @@ class PendingState:
 
     def to_simple_dict(self) -> dict[str, dict]:
         return {
-            "line_activation": {k: v for k, v in self.line_activation.items()},
-            "asset_activation": {k: v for k, v in self.asset_activation.items()}
+            "line_activation": {k.as_int(): v for k, v in self.line_activation.items()},
+            "asset_activation": {k.as_int(): v for k, v in self.asset_activation.items()}
         }
 
     @classmethod
     def from_simple_dict(self, x: dict) -> "PendingState":
         return PendingState(
-            line_activation=MappingProxyType(x["line_activation"]),
-            asset_activation=MappingProxyType(x["asset_activation"])
+            line_activation=MappingProxyType({TransmissionId(k): v for k, v in x["line_activation"].items()}),
+            asset_activation=MappingProxyType({AssetId(k): v for k, v in x["asset_activation"].items()})
         )
 
     @staticmethod

--- a/back_end/src/models/pending_state.py
+++ b/back_end/src/models/pending_state.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass, field
+from types import MappingProxyType
+
+from src.models.ids import AssetId, TransmissionId
+
+_empty_mapping = field(default_factory=lambda: MappingProxyType({}))
+
+@dataclass(frozen=True)
+class PendingState:
+    line_activation: MappingProxyType[TransmissionId, bool] = field(default_factory=lambda: MappingProxyType({}))
+    asset_activation: MappingProxyType[AssetId, bool] = field(default_factory=lambda: MappingProxyType({}))
+
+    def update(self, ps: "PendingState") -> "PendingState":
+        return PendingState(
+            line_activation=self.join_dicts(self.line_activation, ps.line_activation),
+            asset_activation=self.join_dicts(self.asset_activation, ps.asset_activation)
+        )
+
+    def to_simple_dict(self) -> dict[str, dict]:
+        return {
+            "line_activation": {k: v for k, v in self.line_activation.items()},
+            "asset_activation": {k: v for k, v in self.asset_activation.items()}
+        }
+
+    @classmethod
+    def from_simple_dict(self, x: dict) -> "PendingState":
+        return PendingState(
+            line_activation=MappingProxyType(x["line_activation"]),
+            asset_activation=MappingProxyType(x["asset_activation"])
+        )
+
+    @staticmethod
+    def join_dicts[T, U](old: MappingProxyType[T, U], new: MappingProxyType[T, U]) -> MappingProxyType[T, U]:
+        new_dict = {}
+        for d in [old, new]:
+            new_dict.update(d)
+        return MappingProxyType(new_dict)

--- a/back_end/src/models/player.py
+++ b/back_end/src/models/player.py
@@ -68,7 +68,7 @@ class PlayerRepo(LdcRepo[Player]):
 
     # UPDATE
     def _adjust_money(self, player_id: PlayerId, func: Callable[[float], float]) -> Self:
-        df = self.df.copy()
+        df = self.df
         money: float = df.loc[player_id, "money"]  # type: ignore
         df.loc[player_id, "money"] = func(money)
         return self.update_frame(df)
@@ -83,7 +83,7 @@ class PlayerRepo(LdcRepo[Player]):
         return self.add_money(to_player, amount).subtract_money(from_player, amount)
 
     def _set_turn(self, player_id: PlayerId | list[PlayerId], is_having_turn: bool) -> Self:
-        df = self.df.copy()
+        df = self.df
         df.loc[player_id, "is_having_turn"] = is_having_turn
         return self.update_frame(df)
 
@@ -97,7 +97,7 @@ class PlayerRepo(LdcRepo[Player]):
         return self._set_turn(self.human_player_ids, True)
 
     def start_first_player_turn(self) -> Self:
-        df = self.df.copy()
+        df = self.df
         df.loc[:, "is_having_turn"] = False
         df.loc[self.human_player_ids[0], "is_having_turn"] = True
         return self.update_frame(df)
@@ -107,7 +107,7 @@ class PlayerRepo(LdcRepo[Player]):
         assert len(current_players) == 1, f"Expected exactly one current player, got {current_players}"
         current_player = current_players[0]
 
-        df = self.df.copy()
+        df = self.df
         df.loc[current_player, "is_having_turn"] = False
         human_ids = self.human_player_ids
         next_index = human_ids.index(current_players[0]) + 1
@@ -119,7 +119,7 @@ class PlayerRepo(LdcRepo[Player]):
         return self.update_frame(df)
 
     def eliminate_player(self, player_id: PlayerId) -> Self:
-        df = self.df.copy()
+        df = self.df
         df.loc[player_id, "still_alive"] = False
         return self.update_frame(df)
 

--- a/back_end/src/models/server_models.py
+++ b/back_end/src/models/server_models.py
@@ -12,7 +12,7 @@ from types import MappingProxyType
 from pydantic import BaseModel
 
 from src.models.ids import AssetId, GameId, PlayerId, TransmissionId
-from src.models.message import BuyRequest, EndTurn, GameToPlayerMessage, OperateLineRequest, PlayerToGameMessage, UpdateBatchBidsRequest, UpdateBidRequest
+from src.models.message import ActivationUpdateRequest, BuyRequest, EndTurn, GameToPlayerMessage, PlayerToGameMessage, UpdateBatchBidsRequest, UpdateBidRequest
 
 # Serialization handled by message objects directly
 
@@ -59,7 +59,7 @@ class WebsocketMessage(BaseModel):
             UpdateBatchBidsRequest: self._to_batch_bid_request,
             UpdateBidRequest: self._to_bid_request,
             BuyRequest: self._to_buy_request,
-            OperateLineRequest: self._to_operate_line_request,
+            ActivationUpdateRequest: self._to_activation_update_request,
             EndTurn: self._to_end_turn,
         }
         name_func_mapping = {c.get_camel_case_name(): func for c, func in mapping.items()}
@@ -82,12 +82,12 @@ class WebsocketMessage(BaseModel):
             purchase_id=id_type(self.data["purchase_id"]),
         )
 
-    def _to_operate_line_request(self) -> OperateLineRequest:
-        return OperateLineRequest(
+    def _to_activation_update_request(self) -> ActivationUpdateRequest:
+        return ActivationUpdateRequest(
             game_id=self.game_id_obj,
             player_id=self.player_id_obj,
-            transmission_id=TransmissionId(self.data["transmission_id"]),
-            action=self.data["action"],
+            asset_activation=MappingProxyType({AssetId(int(k)): bool(v) for k, v in self.data["asset_activation"].items()}),
+            line_activation=MappingProxyType({TransmissionId(int(k)): bool(v) for k, v in self.data["line_activation"].items()}),
         )
 
     def _to_end_turn(self) -> EndTurn:

--- a/back_end/src/models/transmission.py
+++ b/back_end/src/models/transmission.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from functools import cached_property
+from types import MappingProxyType
 from typing import Self
 
 from src.models.data.ldc_repo import LdcRepo
@@ -86,6 +87,14 @@ class TransmissionRepo(LdcRepo[TransmissionInfo]):
     def close_line(self, transmission_id: TransmissionId) -> Self:
         df = self.df
         df.loc[transmission_id, "is_active"] = True
+        return self.update_frame(df)
+
+    def update_activations(self, activations: MappingProxyType[TransmissionId, bool]) -> Self:
+        df = self.df
+        actives = [k for k, v in activations.items() if v]
+        inactives = [k for k, v in activations.items() if not v]
+        df.loc[actives, "is_active"] = True
+        df.loc[inactives, "is_active"] = False
         return self.update_frame(df)
 
     def change_owner(self, transmission_id: TransmissionId, new_owner: PlayerId) -> Self:

--- a/back_end/src/models/transmission.py
+++ b/back_end/src/models/transmission.py
@@ -91,8 +91,8 @@ class TransmissionRepo(LdcRepo[TransmissionInfo]):
 
     def update_activations(self, activations: MappingProxyType[TransmissionId, bool]) -> Self:
         df = self.df
-        actives = [k for k, v in activations.items() if v]
-        inactives = [k for k, v in activations.items() if not v]
+        actives = [k.as_int() for k, v in activations.items() if v]
+        inactives = [k.as_int() for k, v in activations.items() if not v]
         df.loc[actives, "is_active"] = True
         df.loc[inactives, "is_active"] = False
         return self.update_frame(df)

--- a/back_end/src/models/transmission.py
+++ b/back_end/src/models/transmission.py
@@ -98,7 +98,7 @@ class TransmissionRepo(LdcRepo[TransmissionInfo]):
         return self.update_frame(df)
 
     def change_owner(self, transmission_id: TransmissionId, new_owner: PlayerId) -> Self:
-        df = self.df.copy()
+        df = self.df
         df.loc[transmission_id, "owner_player"] = simplify_type(new_owner)
         df.loc[transmission_id, "is_for_sale"] = False
         return self.update_frame(df)
@@ -106,11 +106,11 @@ class TransmissionRepo(LdcRepo[TransmissionInfo]):
     def wear_transmission(self, transmission_id: TransmissionId) -> Self:
         health: float = self.df.loc[transmission_id, "health"]  # type: ignore
         if health > 1:
-            df = self.df.copy()
+            df = self.df
             df.loc[transmission_id, "health"] -= 1  # type: ignore
             return self.update_frame(df)
         else:
-            df = self.df.copy()
+            df = self.df
             df.loc[transmission_id, "health"] = 0
             df.loc[transmission_id, "is_active"] = False
             return self.update_frame(df)

--- a/back_end/src/new_game/new_game.py
+++ b/back_end/src/new_game/new_game.py
@@ -229,11 +229,11 @@ class GameInitializer:
         topos = iter(topology)
 
         buses: list[Bus] = []
-        for pid, top in zip(player_repo.player_ids, topos):
-            buses.append(Bus(id=next(bus_ids), player_id=pid, x=top.x, y=top.y))
+        for top in topos:
+            buses.append(Bus(id=next(bus_ids), x=top.x, y=top.y))
 
         for bus_id, top in zip(bus_ids, topos):
-            buses.append(Bus(id=bus_id, player_id=PlayerId.get_npc(), x=top.x, y=top.y))
+            buses.append(Bus(id=bus_id, x=top.x, y=top.y))
 
         return BusRepo(buses)
 
@@ -253,11 +253,13 @@ class GameInitializer:
         freezer_bid = int(np.floor(self.settings.initial_funds / freezer_power))
         # The initial freezer bid is the highest affordable bid for the player at the start of the game
 
+        bus_iter = iter(bus_repo.bus_ids)
+
         for player_id in player_repo.player_ids:
             if player_id == PlayerId.get_npc():
                 continue
 
-            bus_id = bus_repo.get_bus_for_player(player_id=player_id).id
+            bus_id = next(bus_iter)
             socket_manager.use_socket(bus_id=bus_id)
 
             assets.append(

--- a/back_end/tests/test_engine/test_engine.py
+++ b/back_end/tests/test_engine/test_engine.py
@@ -1,21 +1,11 @@
+from types import MappingProxyType
+
 from src.engine.engine import Engine
 from src.models.assets import AssetInfo, AssetType
 from src.models.colors import Color
 from src.models.game_state import GameState, Phase
 from src.models.ids import AssetId, GameId, PlayerId, TransmissionId
-from src.models.message import (
-    AssetWornMessage,
-    BuyRequest,
-    BuyResponse,
-    IceCreamMeltedMessage,
-    OperateAssetRequest,
-    OperateAssetResponse,
-    OperateLineRequest,
-    OperateLineResponse,
-    PlayerToGameMessage,
-    TransmissionWornMessage,
-    PlayerNotInTurn,
-)
+from src.models.message import Ack, ActivationUpdateRequest, AssetWornMessage, BuyRequest, BuyResponse, IceCreamMeltedMessage, PlayerNotInTurn, PlayerToGameMessage, TransmissionWornMessage
 from src.models.player import Player
 from src.models.transmission import TransmissionInfo
 from tests.base_test import BaseTest
@@ -142,65 +132,43 @@ class TestEngine(BaseTest):
             bus2=bus_repo.bus_ids[1],
             reactance=10.0,
         )
-        not_my_line = TransmissionInfo(
-            id=TransmissionId(101),
-            owner_player=PlayerId.get_npc(),
-            bus1=bus_repo.bus_ids[2],
-            bus2=bus_repo.bus_ids[3],
-            reactance=10.0,
-        )
         transmission_repo += my_line
-        transmission_repo += not_my_line
 
         game_state = GameStateMaker().add_player_repo(player_repo).add_bus_repo(bus_repo).add_transmission_repo(transmission_repo).add_phase(Phase.SNEAKY_TRICKS).make()
         game_state = give_turn_to_player(game_state, player.id)
 
-        # Test operating a line that I own
-        open_request = OperateLineRequest(game_id=game_state.game_id, player_id=player.id, transmission_id=my_line.id, action="open")
-        game_state, responses = Engine.handle_message(game_state=game_state, msg=open_request)
+
+        deactivate_request = ActivationUpdateRequest(
+            game_id=game_state.game_id,
+            player_id=player.id,
+            line_activation=MappingProxyType({my_line.id: False}),
+            asset_activation=MappingProxyType({})
+        )
+        activate_request = ActivationUpdateRequest(
+            game_id=game_state.game_id,
+            player_id=player.id,
+            line_activation=MappingProxyType({my_line.id: True}),
+            asset_activation=MappingProxyType({})
+        )
+        game_state, responses = Engine.handle_message(game_state=game_state, msg=deactivate_request)
 
         self.assertEqual(len(responses), 1)
         response = responses[0]
-        response = self.assertIsInstance(response, OperateLineResponse)
-        self.assertEqual(response.result, "success")
-        self.assertEqual(game_state.transmission[my_line.id].is_open, True)
+        self.assertIsInstance(response, Ack)
+        self.assertEqual(game_state.transmission[my_line.id].is_active, True)
+        game_state = game_state.commit_pending_state()
+        self.assertEqual(game_state.transmission[my_line.id].is_active, False)
 
-        # Try to open it again
-        game_state, responses = Engine.handle_message(game_state=game_state, msg=open_request)
-
-        self.assertEqual(len(responses), 1)
-        response = responses[0]
-        response = self.assertIsInstance(response, OperateLineResponse)
-        self.assertEqual(response.result, "no_change")
-        self.assertEqual(game_state.transmission[my_line.id].is_open, True)
-
-        # Try closing a line that I own
-        close_request = OperateLineRequest(game_id=game_state.game_id, player_id=player.id, transmission_id=my_line.id, action="close")
-        game_state, responses = Engine.handle_message(game_state=game_state, msg=close_request)
+        game_state, responses = Engine.handle_message(game_state=game_state, msg=deactivate_request)
+        game_state, responses = Engine.handle_message(game_state=game_state, msg=activate_request)
 
         self.assertEqual(len(responses), 1)
         response = responses[0]
-        response = self.assertIsInstance(response, OperateLineResponse)
-        self.assertEqual(response.result, "success")
-        self.assertEqual(game_state.transmission[my_line.id].is_open, False)
+        self.assertIsInstance(response, Ack)
+        self.assertEqual(game_state.transmission[my_line.id].is_active, False)
+        game_state = game_state.commit_pending_state()
+        self.assertEqual(game_state.transmission[my_line.id].is_active, True)
 
-        # Try to close it again
-        game_state, responses = Engine.handle_message(game_state=game_state, msg=close_request)
-
-        self.assertEqual(len(responses), 1)
-        response = responses[0]
-        response = self.assertIsInstance(response, OperateLineResponse)
-        self.assertEqual(response.result, "no_change")
-        self.assertEqual(game_state.transmission[my_line.id].is_open, False)
-
-        # Try to operate a line that I do not own
-        not_my_open_request = OperateLineRequest(game_id=game_state.game_id, player_id=player.id, transmission_id=not_my_line.id, action="open")
-        game_state, responses = Engine.handle_message(game_state=game_state, msg=not_my_open_request)
-        self.assertEqual(len(responses), 1)
-        response = responses[0]
-        response = self.assertIsInstance(response, OperateLineResponse)
-        self.assertEqual(response.result, "failure")
-        self.assertEqual(game_state.transmission[not_my_line.id].is_open, False)
 
     def test_operate_asset_messages(self) -> None:
         player_repo = PlayerRepoMaker.make_quick()
@@ -218,74 +186,42 @@ class TestEngine(BaseTest):
 
         player = player_repo.human_players[0]
         my_generator = AssetInfo(id=AssetId(100), owner_player=player.id, asset_type=AssetType.GENERATOR, bus=bus_repo.bus_ids[0], power_expected=10, power_std=0.0, health=5, is_active=True)
-        my_load = AssetInfo(id=AssetId(101), owner_player=player.id, asset_type=AssetType.LOAD, bus=bus_repo.bus_ids[0], power_expected=10, power_std=0.0, health=5, is_active=True)
-        broke_player_load = AssetInfo(id=AssetId(102), owner_player=broke_player.id, asset_type=AssetType.LOAD, bus=bus_repo.bus_ids[0], power_expected=10, power_std=0.0, health=5, is_active=False)
-        asset_repo = asset_repo + my_generator + my_load + broke_player_load
+        asset_repo = asset_repo.add(my_generator)
 
-        game_state = GameStateMaker().add_player_repo(player_repo).add_bus_repo(bus_repo).add_asset_repo(asset_repo).add_phase(Phase.BIDDING).make()
-        game_state = give_turn_to_player(game_state, player.id)
+        game_state = GameStateMaker().add_player_repo(player_repo).add_bus_repo(bus_repo).add_asset_repo(asset_repo).add_phase(Phase.SNEAKY_TRICKS).make()
 
-        # Test deactivate my generator
-        deactivate_asset = OperateAssetRequest(game_id=game_state.game_id, player_id=player.id, asset_id=my_generator.id, action="shutdown")
-
-        game_state, responses = Engine.handle_message(game_state=game_state, msg=deactivate_asset)
+        deactivate_request = ActivationUpdateRequest(
+            game_id=GameId(0),
+            player_id=player.id,
+            line_activation=MappingProxyType({}),
+            asset_activation=MappingProxyType({my_generator.id: False})
+        )
+        activate_request = ActivationUpdateRequest(
+            game_id=GameId(0),
+            player_id=player.id,
+            line_activation=MappingProxyType({}),
+            asset_activation=MappingProxyType({my_generator.id: True})
+        )
+        game_state, responses = Engine.handle_message(game_state=game_state, msg=deactivate_request)
 
         self.assertEqual(len(responses), 1)
         response = responses[0]
-        response = self.assertIsInstance(response, OperateAssetResponse)
-        self.assertEqual(response.result, "success")
+        self.assertIsInstance(response, Ack)
+        self.assertEqual(game_state.assets[my_generator.id].is_active, True)
+        game_state = game_state.commit_pending_state()
         self.assertEqual(game_state.assets[my_generator.id].is_active, False)
 
-        # Try to deactivate it again
-        game_state, responses = Engine.handle_message(game_state=game_state, msg=deactivate_asset)
+        game_state, responses = Engine.handle_message(game_state=game_state, msg=deactivate_request)
+        game_state, responses = Engine.handle_message(game_state=game_state, msg=activate_request)
 
         self.assertEqual(len(responses), 1)
         response = responses[0]
-        response = self.assertIsInstance(response, OperateAssetResponse)
-        self.assertEqual(response.result, "no_change")
+        self.assertIsInstance(response, Ack)
         self.assertEqual(game_state.assets[my_generator.id].is_active, False)
-
-        # Try activating my generator
-        activate_asset = OperateAssetRequest(game_id=game_state.game_id, player_id=player.id, asset_id=my_generator.id, action="startup")
-
-        game_state, responses = Engine.handle_message(game_state=game_state, msg=activate_asset)
-
-        self.assertEqual(len(responses), 1)
-        response = responses[0]
-        response = self.assertIsInstance(response, OperateAssetResponse)
-        self.assertEqual(response.result, "success")
+        game_state = game_state.commit_pending_state()
         self.assertEqual(game_state.assets[my_generator.id].is_active, True)
 
-        # Try to activate it again
-        game_state, responses = Engine.handle_message(game_state=game_state, msg=activate_asset)
 
-        self.assertEqual(len(responses), 1)
-        response = responses[0]
-        response = self.assertIsInstance(response, OperateAssetResponse)
-        self.assertEqual(response.result, "no_change")
-        self.assertEqual(game_state.assets[my_generator.id].is_active, True)
-
-        # Try to operate an asset that I do not own
-        broke_player_load_activate = OperateAssetRequest(game_id=game_state.game_id, player_id=player.id, asset_id=broke_player_load.id, action="startup")
-
-        game_state, responses = Engine.handle_message(game_state=game_state, msg=broke_player_load_activate)
-
-        self.assertEqual(len(responses), 1)
-        response = responses[0]
-        response = self.assertIsInstance(response, OperateAssetResponse)
-        self.assertEqual(response.result, "failure")
-        self.assertEqual(game_state.assets[broke_player_load.id].is_active, False)
-
-        # Broke player tries to activate their own load
-        broke_player_load_activate = OperateAssetRequest(game_id=game_state.game_id, player_id=broke_player.id, asset_id=broke_player_load.id, action="startup")
-
-        game_state, responses = Engine.handle_message(game_state=game_state, msg=broke_player_load_activate)
-
-        self.assertEqual(len(responses), 1)
-        response = responses[0]
-        response = self.assertIsInstance(response, OperateAssetResponse)
-        self.assertEqual(response.result, "failure")
-        self.assertEqual(game_state.assets[broke_player_load.id].is_active, False)
 
     def test_post_clearing_book_keeping(self):
         game_maker = GameStateMaker()

--- a/back_end/tests/test_engine/test_engine.py
+++ b/back_end/tests/test_engine/test_engine.py
@@ -172,15 +172,6 @@ class TestEngine(BaseTest):
 
     def test_operate_asset_messages(self) -> None:
         player_repo = PlayerRepoMaker.make_quick()
-        broke_player = Player(
-            id=PlayerId(100),
-            name="Broke player",
-            trigram="BRO",
-            color=Color("black"),
-            money=-100,
-            is_having_turn=True,
-        )
-        player_repo += broke_player
         bus_repo = BusRepoMaker.make_quick(n_npc_buses=5, players=player_repo)
         asset_repo = AssetRepoMaker.make_quick(players=player_repo, bus_repo=bus_repo)
 
@@ -189,6 +180,7 @@ class TestEngine(BaseTest):
         asset_repo = asset_repo.add(my_generator)
 
         game_state = GameStateMaker().add_player_repo(player_repo).add_bus_repo(bus_repo).add_asset_repo(asset_repo).add_phase(Phase.SNEAKY_TRICKS).make()
+        game_state = game_state.start_all_turns()
 
         deactivate_request = ActivationUpdateRequest(
             game_id=GameId(0),

--- a/back_end/tests/test_models/test_assets.py
+++ b/back_end/tests/test_models/test_assets.py
@@ -28,8 +28,8 @@ class TestAssets(BaseTest):
         repo = AssetRepoMaker(players=player_ids, bus_repo=bus_repo).add_assets_to_buses(buses=buses).make()
 
         for b, expected_count in {BusId(1): 1, BusId(2): 2, BusId(3): 0}.items():
-            b_assets = repo.get_all_assets_at_bus(b)
-            self.assertEqual(len(b_assets), expected_count)
+            assets = repo.get_all_assets_at_bus(b).not_freezers
+            self.assertEqual(len(assets), expected_count)
 
     def test_delete_assets(self) -> None:
         player_ids = [PlayerId(1), PlayerId(2)]

--- a/back_end/tests/utils/comparisons.py
+++ b/back_end/tests/utils/comparisons.py
@@ -1,9 +1,10 @@
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 import pandas as pd
 
 from src.models.game_state import GameState
 from src.models.market_coupling_result import MarketCouplingResult
+from src.models.pending_state import PendingState
 
 
 class GameStateComparator:
@@ -33,6 +34,7 @@ class GameStateComparator:
             "assets": lambda: game_state1.assets == game_state2.assets,
             "transmission": lambda: game_state1.transmission == game_state2.transmission,
             "market_coupling_result": lambda: cls.market_coupling_result_is_equal(game_state1.market_coupling_result, game_state2.market_coupling_result),
+            "pending_state": lambda: cls.pending_states_are_equal(game_state1.pending_state, game_state2.pending_state)
         }
 
     @staticmethod
@@ -54,6 +56,25 @@ class GameStateComparator:
         if not check_df(result1.assets_dispatch, result2.assets_dispatch):
             return False
         return True
+
+    @classmethod
+    def pending_states_are_equal(cls, ps1: PendingState, ps2: PendingState) -> bool:
+        dict_pairs = [(ps1.asset_activation, ps2.asset_activation), (ps1.line_activation, ps2.line_activation)]
+        for dp in dict_pairs:
+            d1, d2 = dp
+            if not cls.dicts_equal(d1, d2):
+                return False
+        return True
+
+    @staticmethod
+    def dicts_equal(d1: Mapping, d2: Mapping) -> bool:
+        if set(d1.keys()) != set(d2.keys()):
+            return False
+        for k, v in d1.items():
+            if v != d2[k]:
+                return False
+        return True
+
 
 
 def game_states_are_equal(game_state1: GameState, game_state2: GameState) -> bool:

--- a/back_end/tests/utils/game_state_maker.py
+++ b/back_end/tests/utils/game_state_maker.py
@@ -1,3 +1,4 @@
+from types import MappingProxyType
 from typing import Self
 
 import numpy as np
@@ -9,6 +10,7 @@ from src.models.game_settings import GameSettings
 from src.models.game_state import GameState, Phase
 from src.models.ids import GameId, PlayerId, TransmissionId
 from src.models.market_coupling_result import MarketCouplingResult
+from src.models.pending_state import PendingState
 from src.models.player import PlayerRepo
 from src.models.transmission import TransmissionRepo
 from src.tools.random_choice import random_choice, random_choice_multi
@@ -151,6 +153,7 @@ class GameStateMaker:
         self.asset_repo: AssetRepo | None = None
         self.transmission_repo: TransmissionRepo | None = None
         self.market_coupling_result: MarketCouplingResult | None = None
+        self.pending_state: PendingState | None = None
 
     def add_game_id(self, game_id: GameId) -> Self:
         self.game_id = game_id
@@ -206,6 +209,17 @@ class GameStateMaker:
                 asset_repo=self.asset_repo,
                 transmission_repo=self.transmission_repo,
             )
+        if self.pending_state is None:
+            if not (len(self.transmission_repo) and len(self.asset_repo)):
+                self.pending_state = PendingState()
+            else:
+                line_id = self.transmission_repo.transmission_ids[0]
+                asset_id = self.asset_repo.asset_ids[0]
+                self.pending_state = PendingState(
+                    line_activation=MappingProxyType({line_id: True}),
+                    asset_activation=MappingProxyType({asset_id: False})
+                )
+
 
         return GameState(
             game_id=self.game_id,
@@ -216,4 +230,5 @@ class GameStateMaker:
             assets=self.asset_repo,
             transmission=self.transmission_repo,
             market_coupling_result=self.market_coupling_result,
+            pending_state=self.pending_state
         )

--- a/back_end/tests/utils/repo_maker.py
+++ b/back_end/tests/utils/repo_maker.py
@@ -62,10 +62,10 @@ class BusRepoMaker(RepoMaker[BusRepo, Bus]):
             players = players.player_ids
         self.player_ids = players
 
-    def add_bus(self, player_id: PlayerId = PlayerId.get_npc()) -> Self:
-        return self + self._make_dc(player_id=player_id)
+    def add_bus(self) -> Self:
+        return self + self._make_dc()
 
-    def _make_dc(self, player_id: PlayerId = PlayerId.get_npc()) -> Bus:
+    def _make_dc(self) -> Bus:
         map_width: float = 20.0
         half_width = map_width / 2
 
@@ -79,7 +79,7 @@ class BusRepoMaker(RepoMaker[BusRepo, Bus]):
         y = -centre_y + abs(half_width - centre_y) * centre_rand()
 
         bus_id = next(self.id_counter)
-        return Bus(id=BusId(bus_id), x=x, y=y, player_id=player_id, max_assets=20, max_lines=10)
+        return Bus(id=BusId(bus_id), x=x, y=y, max_assets=20, max_lines=10)
 
     def _get_current_centre(self) -> tuple[float, float]:
         """Get the current centre of the buses."""
@@ -93,12 +93,12 @@ class BusRepoMaker(RepoMaker[BusRepo, Bus]):
         return BusRepo
 
     def _pre_make_hook(self) -> None:
-        # Ensure that there is exactly one bus per non-npc player
-        player_ids_with_buses = {bus.player_id for bus in self.dcs if bus.player_id != PlayerId.get_npc()}
-        players_without_buses = set(self.player_ids) - player_ids_with_buses
-
-        for player_id in players_without_buses:
-            self.dcs.append(self._make_dc(player_id=player_id))
+        # Ensure that there is at least one bus per non-npc player
+        n_buses = len(self.dcs)
+        n_players = len(self.player_ids) - 1
+        if n_buses < n_players:
+            for _ in range(n_players - n_buses):
+                self.dcs.append(self._make_dc())
 
 
 class PlayerRepoMaker(RepoMaker[PlayerRepo, Player]):
@@ -161,8 +161,12 @@ class AssetRepoMaker(RepoMaker[AssetRepo, AssetInfo]):
         self.buses = bus_repo
         self._socket_manager = BusSocketManager({b.id: b.max_assets for b in bus_repo})
 
-        for bus in self.buses.freezer_buses:
-            freezer = self._make_dc(cat="Freezer", bus=bus.id, owner=bus.player_id, is_active=True)
+        bus_id_iter = iter(self.buses.bus_ids)
+        for player in players:
+            if player == PlayerId.get_npc():
+                continue
+            bus_id = next(bus_id_iter)
+            freezer = self._make_dc(cat="Freezer", bus=bus_id, owner=player, is_active=True)
             self._safe_append(freezer)
 
     def __add__(self, dc: AssetInfo | list[AssetInfo]) -> Self:

--- a/front_end/package-lock.json
+++ b/front_end/package-lock.json
@@ -759,9 +759,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.14.tgz",
-      "integrity": "sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA=="
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
+      "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "15.5.4",
@@ -804,9 +804,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.14.tgz",
-      "integrity": "sha512-Y9K6SPzobnZvrRDPO2s0grgzC+Egf0CqfbdvYmQVaztV890zicw8Z8+4Vqw8oPck8r1TjUHxVh8299Cg4TrxXg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
+      "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
       "cpu": [
         "arm64"
       ],
@@ -819,9 +819,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.14.tgz",
-      "integrity": "sha512-aNnkSMjSFRTOmkd7qoNI2/rETQm/vKD6c/Ac9BZGa9CtoOzy3c2njgz7LvebQJ8iPxdeTuGnAjagyis8a9ifBw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
+      "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
       "cpu": [
         "x64"
       ],
@@ -834,9 +834,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.14.tgz",
-      "integrity": "sha512-tjlpia+yStPRS//6sdmlVwuO1Rioern4u2onafa5n+h2hCS9MAvMXqpVbSrjgiEOoCs0nJy7oPOmWgtRRNSM5Q==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
+      "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
       "cpu": [
         "arm64"
       ],
@@ -849,9 +849,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.14.tgz",
-      "integrity": "sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
+      "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
       "cpu": [
         "arm64"
       ],
@@ -864,9 +864,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.14.tgz",
-      "integrity": "sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
+      "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
       "cpu": [
         "x64"
       ],
@@ -879,9 +879,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.14.tgz",
-      "integrity": "sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
+      "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
       "cpu": [
         "x64"
       ],
@@ -894,9 +894,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.14.tgz",
-      "integrity": "sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
+      "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
       "cpu": [
         "arm64"
       ],
@@ -909,9 +909,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.14.tgz",
-      "integrity": "sha512-+W7eFf3RS7m4G6tppVTOSyP9Y6FsJXfOuKzav1qKniiFm3KFByQfPEcouHdjlZmysl4zJGuGLQ/M9XyVeyeNEg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
+      "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
       "cpu": [
         "x64"
       ],
@@ -4584,11 +4584,11 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.14.tgz",
-      "integrity": "sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
+      "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
       "dependencies": {
-        "@next/env": "15.5.14",
+        "@next/env": "15.5.15",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -4601,14 +4601,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.14",
-        "@next/swc-darwin-x64": "15.5.14",
-        "@next/swc-linux-arm64-gnu": "15.5.14",
-        "@next/swc-linux-arm64-musl": "15.5.14",
-        "@next/swc-linux-x64-gnu": "15.5.14",
-        "@next/swc-linux-x64-musl": "15.5.14",
-        "@next/swc-win32-arm64-msvc": "15.5.14",
-        "@next/swc-win32-x64-msvc": "15.5.14",
+        "@next/swc-darwin-arm64": "15.5.15",
+        "@next/swc-darwin-x64": "15.5.15",
+        "@next/swc-linux-arm64-gnu": "15.5.15",
+        "@next/swc-linux-arm64-musl": "15.5.15",
+        "@next/swc-linux-x64-gnu": "15.5.15",
+        "@next/swc-linux-x64-musl": "15.5.15",
+        "@next/swc-win32-arm64-msvc": "15.5.15",
+        "@next/swc-win32-x64-msvc": "15.5.15",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {

--- a/front_end/src/app/page.tsx
+++ b/front_end/src/app/page.tsx
@@ -175,24 +175,46 @@ export default function Home() {
     wsClient.buyTransmissionLine(lineId.toString());
   };
 
-  // State for batch bidding
-  const [pendingBids, setPendingBids] = useState<Record<number, number>>({});
+  // State for activation changes during sneaky tricks phase
+  const [pendingActivations, setPendingActivations] = useState<{
+    lines: Record<number, boolean>;
+    assets: Record<number, boolean>;
+  }>({ lines: {}, assets: {} });
 
-  // State to track insufficient funds status from BiddingTable
-  const [hasInsufficientFunds, setHasInsufficientFunds] = useState(false);
-
-  const handleBidAsset = (assetId: number, newBidPrice: number) => {
-    // Store bid locally instead of sending immediately
-    setPendingBids((prev) => ({
+  const handleActivateLine = (lineId: number) => {
+    // Store activation in pending state
+    setPendingActivations((prev) => ({
       ...prev,
-      [assetId]: newBidPrice,
+      lines: { ...prev.lines, [lineId]: true },
     }));
-    console.log("Stored bid for asset:", assetId, "to:", newBidPrice);
+    console.log(`Activating line ${lineId} - stored locally`);
   };
 
-  const handleBidChange = (assetId: number, newBidPrice: number) => {
-    // This is called from the bidding table when input changes
-    handleBidAsset(assetId, newBidPrice);
+  const handleDeactivateLine = (lineId: number) => {
+    // Store deactivation in pending state
+    setPendingActivations((prev) => ({
+      ...prev,
+      lines: { ...prev.lines, [lineId]: false },
+    }));
+    console.log(`Deactivating line ${lineId} - stored locally`);
+  };
+
+  const handleActivateAsset = (assetId: number) => {
+    // Store activation in pending state
+    setPendingActivations((prev) => ({
+      ...prev,
+      assets: { ...prev.assets, [assetId]: true },
+    }));
+    console.log(`Activating asset ${assetId} - stored locally`);
+  };
+
+  const handleDeactivateAsset = (assetId: number) => {
+    // Store deactivation in pending state
+    setPendingActivations((prev) => ({
+      ...prev,
+      assets: { ...prev.assets, [assetId]: false },
+    }));
+    console.log(`Deactivating asset ${assetId} - stored locally`);
   };
 
   const handleSubmitAllBids = () => {
@@ -217,8 +239,44 @@ export default function Home() {
       return;
     }
 
+    // Check if we're in sneaky tricks phase with pending activations
+    if (gameState?.phase === 1) {
+      const hasUpdates =
+        Object.keys(pendingActivations.lines).length > 0 ||
+        Object.keys(pendingActivations.assets).length > 0;
+      if (hasUpdates) {
+        console.log("Submitting activation updates:", pendingActivations);
+        wsClient.activationUpdate({
+          line_activation: pendingActivations.lines,
+          asset_activation: pendingActivations.assets,
+        });
+      }
+      // Always clear pending activations at end of turn
+      setPendingActivations({ lines: {}, assets: {} });
+    }
+
     console.log("Ending turn");
     wsClient.endTurn();
+  };
+
+  // State for batch bidding
+  const [pendingBids, setPendingBids] = useState<Record<number, number>>({});
+
+  // State to track insufficient funds status from BiddingTable
+  const [hasInsufficientFunds, setHasInsufficientFunds] = useState(false);
+
+  const handleBidAsset = (assetId: number, newBidPrice: number) => {
+    // Store bid locally instead of sending immediately
+    setPendingBids((prev) => ({
+      ...prev,
+      [assetId]: newBidPrice,
+    }));
+    console.log("Stored bid for asset:", assetId, "to:", newBidPrice);
+  };
+
+  const handleBidChange = (assetId: number, newBidPrice: number) => {
+    // This is called from the bidding table when input changes
+    handleBidAsset(assetId, newBidPrice);
   };
 
   // Show setup screen if not yet started
@@ -481,7 +539,12 @@ export default function Home() {
                 onPurchaseAsset={handlePurchaseAsset}
                 onPurchaseTransmissionLine={handlePurchaseTransmissionLine}
                 onBidAsset={handleBidAsset}
+                onActivateLine={handleActivateLine}
+                onDeactivateLine={handleDeactivateLine}
+                onActivateAsset={handleActivateAsset}
+                onDeactivateAsset={handleDeactivateAsset}
                 currentPlayer={currentPlayerFromGameState}
+                pendingActivations={pendingActivations}
               />
             </div>
           </div>

--- a/front_end/src/app/page.tsx
+++ b/front_end/src/app/page.tsx
@@ -176,10 +176,16 @@ export default function Home() {
   };
 
   // State for activation changes during sneaky tricks phase
+  // Reset when current player or phase changes
   const [pendingActivations, setPendingActivations] = useState<{
     lines: Record<number, boolean>;
     assets: Record<number, boolean>;
   }>({ lines: {}, assets: {} });
+
+  // Reset pending activations when current player or phase changes
+  useEffect(() => {
+    setPendingActivations({ lines: {}, assets: {} });
+  }, [gameState?.phase, currentPlayerFromGameState]);
 
   const handleActivateLine = (lineId: number) => {
     // Store activation in pending state
@@ -251,9 +257,9 @@ export default function Home() {
           asset_activation: pendingActivations.assets,
         });
       }
-      // Always clear pending activations at end of turn
-      setPendingActivations({ lines: {}, assets: {} });
     }
+    // Clear pending activations at end of turn
+    setPendingActivations({ lines: {}, assets: {} });
 
     console.log("Ending turn");
     wsClient.endTurn();

--- a/front_end/src/components/Game/Asset.tsx
+++ b/front_end/src/components/Game/Asset.tsx
@@ -37,6 +37,7 @@ interface AssetProps {
   isActive?: boolean;
   onActivate?: (assetId: number) => void;
   onDeactivate?: (assetId: number) => void;
+  playerHasNegativeMoney?: boolean;
 }
 
 const technologyMap: { [key: string]: React.ElementType } = {
@@ -69,6 +70,7 @@ const AssetComponent: React.FC<AssetProps> = ({
   isActive,
   onActivate,
   onDeactivate,
+  playerHasNegativeMoney = false,
 }) => {
   const formatMoney = (amount: number) => `$${amount.toLocaleString()}`;
   const formatPrice = (price: number) => `$${price.toFixed(2)}/MWh`;
@@ -81,6 +83,15 @@ const AssetComponent: React.FC<AssetProps> = ({
 
   // Use provided isActive prop if available, otherwise fall back to asset.is_active
   const displayActive = isActive !== undefined ? isActive : asset.is_active;
+
+  // Loads (asset_type === 1) should be forced inactive if player has negative money
+  const isLoad = asset.asset_type === AssetType.LOAD;
+  // Freezers cannot be disabled
+  const isFreezer = asset.is_freezer;
+  const isForcedInactive = isLoad && !isFreezer && playerHasNegativeMoney;
+
+  // Determine if the asset can be toggled (not forced inactive, and not a freezer)
+  const canToggle = !isForcedInactive && !isFreezer;
 
   const getAssetData = () => {
     const data: { [key: string]: string } = {
@@ -107,7 +118,11 @@ const AssetComponent: React.FC<AssetProps> = ({
       data["Health"] = asset.health.toString();
     }
 
-    data["Status"] = displayActive ? "ACTIVE" : "INACTIVE";
+    if (isForcedInactive) {
+      data["Status"] = "INACTIVE (Negative Money)";
+    } else {
+      data["Status"] = displayActive ? "ACTIVE" : "INACTIVE";
+    }
 
     return data;
   };
@@ -147,17 +162,22 @@ const AssetComponent: React.FC<AssetProps> = ({
 
   const handleActivationHover = (event: React.MouseEvent) => {
     event.stopPropagation();
+    const actionData: { [key: string]: string } = { ...getAssetData() };
+    if (isFreezer) {
+      actionData["Action"] = "Freezers cannot be disabled";
+    } else if (!canToggle) {
+      actionData["Action"] = "Cannot activate - player has negative money";
+    } else if (displayActive) {
+      actionData["Action"] = "Click to deactivate this asset";
+    } else {
+      actionData["Action"] = "Click to activate this asset";
+    }
     onHover(
       {
         type: "asset",
         id: asset.id,
         title: getAssetTitle(),
-        data: {
-          ...getAssetData(),
-          Action: displayActive
-            ? "Click to deactivate this asset"
-            : "Click to activate this asset",
-        },
+        data: actionData,
       },
       event,
     );
@@ -172,7 +192,9 @@ const AssetComponent: React.FC<AssetProps> = ({
   };
 
   const getAssetColor = () => {
-    return displayActive ? owner.color : adjustColor(owner.color, 0.5);
+    // Always show as inactive if forced
+    const shouldBeInactive = isForcedInactive || !displayActive;
+    return shouldBeInactive ? adjustColor(owner.color, 0.5) : owner.color;
   };
 
   const adjustColor = (color: string, factor: number) => {
@@ -321,34 +343,41 @@ const AssetComponent: React.FC<AssetProps> = ({
       )}
 
       {/* Activation control for owned assets in sneaky tricks phase */}
-      {isOwnedByCurrentPlayer && isSneakyTricks && viewMode === "normal" && (
-        <g className="activation-button" opacity="0.9">
-          <circle
-            cx={buyLocation.x}
-            cy={buyLocation.y}
-            r="12"
-            fill={owner.color}
-            stroke="white"
-            strokeWidth="2"
-            style={{ cursor: "pointer" }}
-            onClick={
-              displayActive ? handleDeactivateClick : handleActivateClick
-            }
-            onMouseEnter={handleActivationHover}
-            onMouseLeave={onLeave}
-          />
-          {/* Open circuit indicator - diagonal line when INACTIVE */}
-          {!displayActive && (
-            <path
-              d={`M ${buyLocation.x - 8} ${buyLocation.y - 8} L ${buyLocation.x + 8} ${buyLocation.y + 8}`}
+      {isOwnedByCurrentPlayer &&
+        isSneakyTricks &&
+        viewMode === "normal" &&
+        canToggle && (
+          <g className="activation-button" opacity="0.9">
+            <circle
+              cx={buyLocation.x}
+              cy={buyLocation.y}
+              r="12"
+              fill={owner.color}
               stroke="white"
               strokeWidth="2"
-              strokeLinecap="round"
-              pointerEvents="none"
+              style={{ cursor: "pointer" }}
+              onClick={
+                isForcedInactive
+                  ? undefined
+                  : displayActive
+                    ? handleDeactivateClick
+                    : handleActivateClick
+              }
+              onMouseEnter={handleActivationHover}
+              onMouseLeave={onLeave}
             />
-          )}
-        </g>
-      )}
+            {/* Open circuit indicator - diagonal line when INACTIVE or forced inactive */}
+            {(isForcedInactive || !displayActive) && (
+              <path
+                d={`M ${buyLocation.x - 8} ${buyLocation.y - 8} L ${buyLocation.x + 8} ${buyLocation.y + 8}`}
+                stroke="white"
+                strokeWidth="2"
+                strokeLinecap="round"
+                pointerEvents="none"
+              />
+            )}
+          </g>
+        )}
     </g>
   );
 };

--- a/front_end/src/components/Game/Asset.tsx
+++ b/front_end/src/components/Game/Asset.tsx
@@ -150,6 +150,8 @@ const AssetComponent: React.FC<AssetProps> = ({
     event.stopPropagation();
     if (onActivate) {
       onActivate(asset.id);
+      // If we're currently hovering over this asset, update the hover data
+      // This will be handled by the parent component's state update
     }
   };
 
@@ -157,6 +159,8 @@ const AssetComponent: React.FC<AssetProps> = ({
     event.stopPropagation();
     if (onDeactivate) {
       onDeactivate(asset.id);
+      // If we're currently hovering over this asset, update the hover data
+      // This will be handled by the parent component's state update
     }
   };
 
@@ -218,15 +222,15 @@ const AssetComponent: React.FC<AssetProps> = ({
     return brightness > 128 ? "#000000" : "#FFFFFF";
   };
 
-  const getBuyLocation = (bus: BusWithDisplayCoords, position: Position) => {
+  const getButtonLocation = (bus: BusWithDisplayCoords, position: Position) => {
     const x_offset = position.x - bus.display_position.x;
     const y_offset = position.y - bus.display_position.y;
-    const buy_x = bus.display_position.x + x_offset * 1.5;
-    const buy_y = bus.display_position.y + y_offset * 1.5;
+    const buy_x = bus.display_position.x + x_offset * 1.6;
+    const buy_y = bus.display_position.y + y_offset * 1.6;
     return { x: buy_x, y: buy_y } as Position;
   };
 
-  const buyLocation = getBuyLocation(bus, position);
+  const buttonLocation = getButtonLocation(bus, position);
   const radius = 5; // Increased from 12
   const fillColor = getAssetColor();
   const textColor = getContrastColor(fillColor);
@@ -317,8 +321,8 @@ const AssetComponent: React.FC<AssetProps> = ({
       {isPurchasable && viewMode === "normal" && (
         <g className="purchase-button" opacity="0.9">
           <circle
-            cx={buyLocation.x}
-            cy={buyLocation.y}
+            cx={buttonLocation.x}
+            cy={buttonLocation.y}
             r="10"
             fill={canAfford ? "#22c55e" : "#9ca3af"}
             stroke="white"
@@ -329,8 +333,8 @@ const AssetComponent: React.FC<AssetProps> = ({
             onMouseLeave={onLeave}
           />
           <text
-            x={buyLocation.x}
-            y={buyLocation.y + 4}
+            x={buttonLocation.x}
+            y={buttonLocation.y + 4}
             textAnchor="middle"
             fontSize="10"
             fill="white"
@@ -349,10 +353,10 @@ const AssetComponent: React.FC<AssetProps> = ({
         canToggle && (
           <g className="activation-button" opacity="0.9">
             <circle
-              cx={buyLocation.x}
-              cy={buyLocation.y}
-              r="12"
-              fill={owner.color}
+              cx={buttonLocation.x}
+              cy={buttonLocation.y}
+              r="10"
+              fill={displayActive ? "#22c55e" : "#9ca3af"}
               stroke="white"
               strokeWidth="2"
               style={{ cursor: "pointer" }}
@@ -366,15 +370,31 @@ const AssetComponent: React.FC<AssetProps> = ({
               onMouseEnter={handleActivationHover}
               onMouseLeave={onLeave}
             />
-            {/* Open circuit indicator - diagonal line when INACTIVE or forced inactive */}
-            {(isForcedInactive || !displayActive) && (
-              <path
-                d={`M ${buyLocation.x - 8} ${buyLocation.y - 8} L ${buyLocation.x + 8} ${buyLocation.y + 8}`}
-                stroke="white"
-                strokeWidth="2"
-                strokeLinecap="round"
+            {/* Tick for ACTIVE, cross for INACTIVE */}
+            {displayActive ? (
+              <text
+                x={buttonLocation.x}
+                y={buttonLocation.y + 4}
+                textAnchor="middle"
+                fontSize="10"
+                fill="white"
                 pointerEvents="none"
-              />
+                fontWeight="bold"
+              >
+                ✓
+              </text>
+            ) : (
+              <text
+                x={buttonLocation.x}
+                y={buttonLocation.y + 4}
+                textAnchor="middle"
+                fontSize="10"
+                fill="white"
+                pointerEvents="none"
+                fontWeight="bold"
+              >
+                ✗
+              </text>
             )}
           </g>
         )}

--- a/front_end/src/components/Game/Asset.tsx
+++ b/front_end/src/components/Game/Asset.tsx
@@ -32,6 +32,11 @@ interface AssetProps {
   playerMoney?: number;
   currentPlayer?: number;
   viewMode?: "normal" | "market";
+  isOwnedByCurrentPlayer?: boolean;
+  isSneakyTricks?: boolean;
+  isActive?: boolean;
+  onActivate?: (assetId: number) => void;
+  onDeactivate?: (assetId: number) => void;
 }
 
 const technologyMap: { [key: string]: React.ElementType } = {
@@ -59,6 +64,11 @@ const AssetComponent: React.FC<AssetProps> = ({
   playerMoney = 0,
   currentPlayer,
   viewMode = "normal",
+  isOwnedByCurrentPlayer = false,
+  isSneakyTricks = false,
+  isActive,
+  onActivate,
+  onDeactivate,
 }) => {
   const formatMoney = (amount: number) => `$${amount.toLocaleString()}`;
   const formatPrice = (price: number) => `$${price.toFixed(2)}/MWh`;
@@ -68,6 +78,9 @@ const AssetComponent: React.FC<AssetProps> = ({
     const title = `${type}${asset.id}`;
     return asset.is_freezer ? `${title} (Freezer)` : title;
   };
+
+  // Use provided isActive prop if available, otherwise fall back to asset.is_active
+  const displayActive = isActive !== undefined ? isActive : asset.is_active;
 
   const getAssetData = () => {
     const data: { [key: string]: string } = {
@@ -94,6 +107,8 @@ const AssetComponent: React.FC<AssetProps> = ({
       data["Health"] = asset.health.toString();
     }
 
+    data["Status"] = displayActive ? "ACTIVE" : "INACTIVE";
+
     return data;
   };
 
@@ -116,6 +131,38 @@ const AssetComponent: React.FC<AssetProps> = ({
     }
   };
 
+  const handleActivateClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    if (onActivate) {
+      onActivate(asset.id);
+    }
+  };
+
+  const handleDeactivateClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    if (onDeactivate) {
+      onDeactivate(asset.id);
+    }
+  };
+
+  const handleActivationHover = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    onHover(
+      {
+        type: "asset",
+        id: asset.id,
+        title: getAssetTitle(),
+        data: {
+          ...getAssetData(),
+          Action: displayActive
+            ? "Click to deactivate this asset"
+            : "Click to activate this asset",
+        },
+      },
+      event,
+    );
+  };
+
   const getAssetText = () => {
     if (asset.asset_type === AssetType.GENERATOR) return "G";
     if (asset.asset_type === AssetType.LOAD) {
@@ -125,7 +172,7 @@ const AssetComponent: React.FC<AssetProps> = ({
   };
 
   const getAssetColor = () => {
-    return asset.is_active ? owner.color : adjustColor(owner.color, 0.5);
+    return displayActive ? owner.color : adjustColor(owner.color, 0.5);
   };
 
   const adjustColor = (color: string, factor: number) => {
@@ -270,6 +317,36 @@ const AssetComponent: React.FC<AssetProps> = ({
           >
             $
           </text>
+        </g>
+      )}
+
+      {/* Activation control for owned assets in sneaky tricks phase */}
+      {isOwnedByCurrentPlayer && isSneakyTricks && viewMode === "normal" && (
+        <g className="activation-button" opacity="0.9">
+          <circle
+            cx={buyLocation.x}
+            cy={buyLocation.y}
+            r="12"
+            fill={owner.color}
+            stroke="white"
+            strokeWidth="2"
+            style={{ cursor: "pointer" }}
+            onClick={
+              displayActive ? handleDeactivateClick : handleActivateClick
+            }
+            onMouseEnter={handleActivationHover}
+            onMouseLeave={onLeave}
+          />
+          {/* Open circuit indicator - diagonal line when INACTIVE */}
+          {!displayActive && (
+            <path
+              d={`M ${buyLocation.x - 8} ${buyLocation.y - 8} L ${buyLocation.x + 8} ${buyLocation.y + 8}`}
+              stroke="white"
+              strokeWidth="2"
+              strokeLinecap="round"
+              pointerEvents="none"
+            />
+          )}
         </g>
       )}
     </g>

--- a/front_end/src/components/Game/BiddingTable.tsx
+++ b/front_end/src/components/Game/BiddingTable.tsx
@@ -37,12 +37,12 @@ const BiddingTable: React.FC<BiddingTableProps> = ({
         ? pendingBids[asset.id]
         : asset.bid_price;
 
-    if (asset.asset_type === AssetType.LOAD) {
-      // For loads: power_expected * (marginal_cost - bid_price)
+    if (asset.asset_type === AssetType.GENERATOR) {
+      // For generators: power_expected * (marginal_cost - bid_price)
       const cashflow = asset.power_expected * (asset.marginal_cost - bidPrice);
       return Math.max(0, cashflow); // Clip negative values to zero
     } else {
-      // For generators: power_expected * (bid_price - marginal_cost)
+      // For loads: power_expected * (bid_price - marginal_cost)
       const cashflow = asset.power_expected * (bidPrice - asset.marginal_cost);
       return Math.max(0, cashflow); // Clip negative values to zero
     }
@@ -53,7 +53,10 @@ const BiddingTable: React.FC<BiddingTableProps> = ({
     return sum + calculate_cost(asset);
   }, 0);
 
-  const insufficientFunds = totalCost > playerMoney;
+  // Clip player money to minimum of 0 for insufficient funds calculation
+  // This allows players with negative money to still place bids
+  const availableFunds = Math.max(0, playerMoney);
+  const insufficientFunds = totalCost > availableFunds;
 
   // Notify parent component about insufficient funds status
   React.useEffect(() => {
@@ -185,7 +188,7 @@ const BiddingTable: React.FC<BiddingTableProps> = ({
             <p
               className={`text-lg font-bold ${insufficientFunds ? "text-red-600" : "text-green-600"}`}
             >
-              {formatNumber(totalCost)} / {formatNumber(playerMoney)}
+              {formatNumber(totalCost)} / {formatNumber(availableFunds)}
             </p>
           </div>
         </div>

--- a/front_end/src/components/Game/Bus.tsx
+++ b/front_end/src/components/Game/Bus.tsx
@@ -5,7 +5,6 @@ import React from "react";
 
 interface BusProps {
   bus: BusWithDisplayCoords;
-  owner: Player;
   onHover: (element: HoverableElement, event: React.MouseEvent) => void;
   onLeave: () => void;
   onClickProp?: (busId: number, event: React.MouseEvent) => void;
@@ -14,7 +13,6 @@ interface BusProps {
 
 const BusComponent: React.FC<BusProps> = ({
   bus,
-  owner,
   onHover,
   onLeave,
   onClickProp,
@@ -27,9 +25,7 @@ const BusComponent: React.FC<BusProps> = ({
           type: "bus",
           id: bus.id,
           title: `Bus${bus.id}`,
-          data: {
-            Owner: owner.trigram,
-          },
+          data: {},
         },
         event,
       );
@@ -67,7 +63,7 @@ const BusComponent: React.FC<BusProps> = ({
         y={bus.display_position.y ? bus.display_position.y - 6 : bus.y - 6}
         width={36}
         height={12}
-        fill={owner.color}
+        fill="#000000"
         stroke="#374151"
         strokeWidth="1"
         rx="2"

--- a/front_end/src/components/Game/GridVisualization.tsx
+++ b/front_end/src/components/Game/GridVisualization.tsx
@@ -9,7 +9,7 @@ import {
   Player,
   NPC_PLAYER_ID,
 } from "@/types/game";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import ConfirmationDialog from "../UI/ConfirmationDialog";
 import ViewToggle from "../UI/ViewToggle";
 import AssetComponent from "./Asset";
@@ -51,6 +51,7 @@ const GridVisualization: React.FC<GridVisualizationProps> = ({
     null,
   );
   const [hoverPosition, setHoverPosition] = useState({ x: 0, y: 0 });
+
   const [selectedBusForMarket, setSelectedBusForMarket] = useState<
     number | null
   >(null);
@@ -69,6 +70,83 @@ const GridVisualization: React.FC<GridVisualizationProps> = ({
     price: number;
   }>({ isOpen: false, type: "asset", id: -1, title: "", price: 0 });
   const [viewMode, setViewMode] = useState<"normal" | "market">("normal");
+
+  // Wrapper functions for activation that update hover state
+  const handleActivateAssetWrapper = useCallback(
+    (assetId: number) => {
+      if (onActivateAsset) {
+        onActivateAsset(assetId);
+        // Activation state will be handled by pendingActivations prop
+        // If this asset is currently hovered, update the hover data
+        if (hoveredElement?.type === "asset" && hoveredElement.id === assetId) {
+          setHoveredElement((prev) => 
+            prev ? {
+              ...prev,
+              data: { ...prev.data, Status: "ACTIVE" },
+            } : null
+          );
+        }
+      }
+    },
+    [onActivateAsset, hoveredElement],
+  );
+
+  const handleDeactivateAssetWrapper = useCallback(
+    (assetId: number) => {
+      if (onDeactivateAsset) {
+        onDeactivateAsset(assetId);
+        // Activation state will be handled by pendingActivations prop
+        // If this asset is currently hovered, update the hover data
+        if (hoveredElement?.type === "asset" && hoveredElement.id === assetId) {
+          setHoveredElement((prev) => 
+            prev ? {
+              ...prev,
+              data: { ...prev.data, Status: "INACTIVE" },
+            } : null
+          );
+        }
+      }
+    },
+    [onDeactivateAsset, hoveredElement],
+  );
+
+  const handleActivateLineWrapper = useCallback(
+    (lineId: number) => {
+      if (onActivateLine) {
+        onActivateLine(lineId);
+        // Activation state will be handled by pendingActivations prop
+        // If this line is currently hovered, update the hover data
+        if (hoveredElement?.type === "line" && hoveredElement.id === lineId) {
+          setHoveredElement((prev) => 
+            prev ? {
+              ...prev,
+              data: { ...prev.data, Status: "CLOSED" },
+            } : null
+          );
+        }
+      }
+    },
+    [onActivateLine, hoveredElement],
+  );
+
+  const handleDeactivateLineWrapper = useCallback(
+    (lineId: number) => {
+      if (onDeactivateLine) {
+        onDeactivateLine(lineId);
+        // Activation state will be handled by pendingActivations prop
+        // If this line is currently hovered, update the hover data
+        if (hoveredElement?.type === "line" && hoveredElement.id === lineId) {
+          setHoveredElement((prev) => 
+            prev ? {
+              ...prev,
+              data: { ...prev.data, Status: "OPEN" },
+            } : null
+          );
+        }
+      }
+    },
+    [onDeactivateLine, hoveredElement],
+  );
 
   const handleElementHover = (
     element: HoverableElement,
@@ -419,8 +497,8 @@ const GridVisualization: React.FC<GridVisualizationProps> = ({
               isOwnedByCurrentPlayer={isOwnedByCurrentPlayer}
               isSneakyTricks={isSneakyTricks}
               isActive={isLineActive}
-              onActivate={onActivateLine}
-              onDeactivate={onDeactivateLine}
+              onActivate={handleActivateLineWrapper}
+              onDeactivate={handleDeactivateLineWrapper}
             />
           );
         })}
@@ -484,8 +562,8 @@ const GridVisualization: React.FC<GridVisualizationProps> = ({
                 isOwnedByCurrentPlayer={isOwnedByCurrentPlayer}
                 isSneakyTricks={isSneakyTricks}
                 isActive={isAssetActive}
-                onActivate={onActivateAsset}
-                onDeactivate={onDeactivateAsset}
+                onActivate={handleActivateAssetWrapper}
+                onDeactivate={handleDeactivateAssetWrapper}
                 playerHasNegativeMoney={playerHasNegativeMoney}
               />
             );

--- a/front_end/src/components/Game/GridVisualization.tsx
+++ b/front_end/src/components/Game/GridVisualization.tsx
@@ -25,14 +25,27 @@ interface GridVisualizationProps {
   onPurchaseAsset?: (assetId: number) => void;
   onPurchaseTransmissionLine?: (lineId: number) => void;
   onBidAsset?: (assetId: number, newBidPrice: number) => void;
+  onActivateLine?: (lineId: number) => void;
+  onDeactivateLine?: (lineId: number) => void;
+  onActivateAsset?: (assetId: number) => void;
+  onDeactivateAsset?: (assetId: number) => void;
   currentPlayer?: number;
+  pendingActivations?: {
+    lines?: Record<number, boolean>;
+    assets?: Record<number, boolean>;
+  };
 }
 
 const GridVisualization: React.FC<GridVisualizationProps> = ({
   gameState,
   onPurchaseAsset,
   onPurchaseTransmissionLine,
+  onActivateLine,
+  onDeactivateLine,
+  onActivateAsset,
+  onDeactivateAsset,
   currentPlayer,
+  pendingActivations = {},
 }) => {
   const [hoveredElement, setHoveredElement] = useState<HoverableElement | null>(
     null,
@@ -374,6 +387,16 @@ const GridVisualization: React.FC<GridVisualizationProps> = ({
             }
           }
 
+          // Check if player owns this line and we're in sneaky tricks phase
+          const isOwnedByCurrentPlayer =
+            currentPlayer !== undefined && line.owner_player === currentPlayer;
+          const isSneakyTricks = gameState.phase === GamePhase.SNEAKY_TRICKS;
+
+          // Get pending activation state if available, otherwise use game state
+          const pendingLineActive = pendingActivations.lines?.[line.id];
+          const isLineActive =
+            pendingLineActive !== undefined ? pendingLineActive : line.is_open;
+
           return (
             <TransmissionLineComponent
               key={line.id}
@@ -392,6 +415,12 @@ const GridVisualization: React.FC<GridVisualizationProps> = ({
               maxFlow={maxFlow}
               actualFlow={linePower}
               showFlowAnimation={true}
+              currentPlayer={currentPlayer}
+              isOwnedByCurrentPlayer={isOwnedByCurrentPlayer}
+              isSneakyTricks={isSneakyTricks}
+              isActive={isLineActive}
+              onActivate={onActivateLine}
+              onDeactivate={onDeactivateLine}
             />
           );
         })}
@@ -421,6 +450,20 @@ const GridVisualization: React.FC<GridVisualizationProps> = ({
             const owner = getPlayerById(asset.owner_player);
             if (!owner) return null;
             const isPurchasable = isAssetPurchasable(asset);
+
+            // Check if player owns this asset and we're in sneaky tricks phase
+            const isOwnedByCurrentPlayer =
+              currentPlayer !== undefined &&
+              asset.owner_player === currentPlayer;
+            const isSneakyTricks = gameState.phase === GamePhase.SNEAKY_TRICKS;
+
+            // Get pending activation state if available, otherwise use game state
+            const pendingAssetActive = pendingActivations.assets?.[asset.id];
+            const isAssetActive =
+              pendingAssetActive !== undefined
+                ? pendingAssetActive
+                : asset.is_active;
+
             return (
               <AssetComponent
                 key={asset.id}
@@ -435,6 +478,11 @@ const GridVisualization: React.FC<GridVisualizationProps> = ({
                 playerMoney={getCurrentPlayerMoney()}
                 currentPlayer={currentPlayer}
                 viewMode={viewMode}
+                isOwnedByCurrentPlayer={isOwnedByCurrentPlayer}
+                isSneakyTricks={isSneakyTricks}
+                isActive={isAssetActive}
+                onActivate={onActivateAsset}
+                onDeactivate={onDeactivateAsset}
               />
             );
           }),

--- a/front_end/src/components/Game/GridVisualization.tsx
+++ b/front_end/src/components/Game/GridVisualization.tsx
@@ -464,6 +464,9 @@ const GridVisualization: React.FC<GridVisualizationProps> = ({
                 ? pendingAssetActive
                 : asset.is_active;
 
+            // Check if player has negative money
+            const playerHasNegativeMoney = getCurrentPlayerMoney() < 0;
+
             return (
               <AssetComponent
                 key={asset.id}
@@ -483,6 +486,7 @@ const GridVisualization: React.FC<GridVisualizationProps> = ({
                 isActive={isAssetActive}
                 onActivate={onActivateAsset}
                 onDeactivate={onDeactivateAsset}
+                playerHasNegativeMoney={playerHasNegativeMoney}
               />
             );
           }),

--- a/front_end/src/components/Game/GridVisualization.tsx
+++ b/front_end/src/components/Game/GridVisualization.tsx
@@ -79,11 +79,13 @@ const GridVisualization: React.FC<GridVisualizationProps> = ({
         // Activation state will be handled by pendingActivations prop
         // If this asset is currently hovered, update the hover data
         if (hoveredElement?.type === "asset" && hoveredElement.id === assetId) {
-          setHoveredElement((prev) => 
-            prev ? {
-              ...prev,
-              data: { ...prev.data, Status: "ACTIVE" },
-            } : null
+          setHoveredElement((prev) =>
+            prev
+              ? {
+                  ...prev,
+                  data: { ...prev.data, Status: "ACTIVE" },
+                }
+              : null,
           );
         }
       }
@@ -98,11 +100,13 @@ const GridVisualization: React.FC<GridVisualizationProps> = ({
         // Activation state will be handled by pendingActivations prop
         // If this asset is currently hovered, update the hover data
         if (hoveredElement?.type === "asset" && hoveredElement.id === assetId) {
-          setHoveredElement((prev) => 
-            prev ? {
-              ...prev,
-              data: { ...prev.data, Status: "INACTIVE" },
-            } : null
+          setHoveredElement((prev) =>
+            prev
+              ? {
+                  ...prev,
+                  data: { ...prev.data, Status: "INACTIVE" },
+                }
+              : null,
           );
         }
       }
@@ -117,11 +121,13 @@ const GridVisualization: React.FC<GridVisualizationProps> = ({
         // Activation state will be handled by pendingActivations prop
         // If this line is currently hovered, update the hover data
         if (hoveredElement?.type === "line" && hoveredElement.id === lineId) {
-          setHoveredElement((prev) => 
-            prev ? {
-              ...prev,
-              data: { ...prev.data, Status: "CLOSED" },
-            } : null
+          setHoveredElement((prev) =>
+            prev
+              ? {
+                  ...prev,
+                  data: { ...prev.data, Status: "CLOSED" },
+                }
+              : null,
           );
         }
       }
@@ -136,11 +142,13 @@ const GridVisualization: React.FC<GridVisualizationProps> = ({
         // Activation state will be handled by pendingActivations prop
         // If this line is currently hovered, update the hover data
         if (hoveredElement?.type === "line" && hoveredElement.id === lineId) {
-          setHoveredElement((prev) => 
-            prev ? {
-              ...prev,
-              data: { ...prev.data, Status: "OPEN" },
-            } : null
+          setHoveredElement((prev) =>
+            prev
+              ? {
+                  ...prev,
+                  data: { ...prev.data, Status: "OPEN" },
+                }
+              : null,
           );
         }
       }
@@ -505,13 +513,10 @@ const GridVisualization: React.FC<GridVisualizationProps> = ({
 
         {/* Buses */}
         {busesWithDisplayCoords.map((bus) => {
-          const owner = getPlayerById(bus.player_id);
-          if (!owner) return null;
           return (
             <BusComponent
               key={bus.id}
               bus={bus}
-              owner={owner}
               onHover={handleElementHover}
               onLeave={handleMouseLeave}
               onClickProp={
@@ -541,6 +546,9 @@ const GridVisualization: React.FC<GridVisualizationProps> = ({
               pendingAssetActive !== undefined
                 ? pendingAssetActive
                 : asset.is_active;
+            {
+              owner.color;
+            }
 
             // Check if player has negative money
             const playerHasNegativeMoney = getCurrentPlayerMoney() < 0;

--- a/front_end/src/components/Game/TransmissionLine.tsx
+++ b/front_end/src/components/Game/TransmissionLine.tsx
@@ -191,7 +191,7 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
 
   const lineAngle = Math.atan2(baseVector.y, baseVector.x);
   const perpAngle = lineAngle + Math.PI / 2; // Perpendicular angle
-  const perpVector: Point = {x: Math.cos(perpAngle), y: Math.sin(perpAngle)}
+  const perpVector: Point = { x: Math.cos(perpAngle), y: Math.sin(perpAngle) };
 
   // Add slight curve by offsetting the middle point
   const curveOffset = 0.1;
@@ -209,7 +209,10 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
   const curveMidY = (midPoint.y + midY) / 2;
   const curveMid: Point = { x: curveMidX, y: curveMidY };
 
-  const buttonPoint: Point = { x: curveMid.x + perpVector.x * -15, y: curveMid.y + perpVector.y * -15};
+  const buttonPoint: Point = {
+    x: curveMid.x + perpVector.x * -15,
+    y: curveMid.y + perpVector.y * -15,
+  };
 
   // Calculate line for open circuit indicator
 

--- a/front_end/src/components/Game/TransmissionLine.tsx
+++ b/front_end/src/components/Game/TransmissionLine.tsx
@@ -22,6 +22,12 @@ interface TransmissionLineProps {
   maxFlow?: number;
   actualFlow?: number;
   showFlowAnimation?: boolean;
+  currentPlayer?: number;
+  isOwnedByCurrentPlayer?: boolean;
+  isSneakyTricks?: boolean;
+  isActive?: boolean;
+  onActivate?: (lineId: number) => void;
+  onDeactivate?: (lineId: number) => void;
 }
 
 const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
@@ -38,11 +44,20 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
   maxFlow = 1,
   actualFlow = 0,
   showFlowAnimation = false,
+  currentPlayer,
+  isOwnedByCurrentPlayer = false,
+  isSneakyTricks = false,
+  isActive,
+  onActivate,
+  onDeactivate,
 }) => {
   const fromBus = buses.find((b) => b.id === line.bus1);
   const toBus = buses.find((b) => b.id === line.bus2);
 
   if (!fromBus || !toBus) return null;
+
+  // Use provided isActive prop if available, otherwise fall back to line.is_open
+  const displayActive = isActive !== undefined ? isActive : line.is_open;
 
   const getLineData = () => {
     const data: { [key: string]: string } = {
@@ -55,9 +70,7 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
         `$${line.minimum_acquisition_price.toLocaleString()}`;
     }
 
-    if (line.is_open) {
-      data["Status"] = "OPEN";
-    }
+    data["Status"] = displayActive ? "OPEN" : "CLOSED";
 
     return data;
   };
@@ -81,8 +94,40 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
     }
   };
 
+  const handleActivateClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    if (onActivate) {
+      onActivate(line.id);
+    }
+  };
+
+  const handleDeactivateClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    if (onDeactivate) {
+      onDeactivate(line.id);
+    }
+  };
+
+  const handleActivationHover = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    onHover(
+      {
+        type: "line",
+        id: line.id,
+        title: `Line${line.id}`,
+        data: {
+          ...getLineData(),
+          Action: displayActive
+            ? "Click to close (deactivate) this line"
+            : "Click to open (activate) this line",
+        },
+      },
+      event,
+    );
+  };
+
   const getLineColor = () => {
-    if (line.is_open) {
+    if (displayActive) {
       // Deactivate color similar to the Python implementation
       return adjustColor(owner.color, 0.5);
     }
@@ -274,6 +319,36 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
           >
             $
           </text>
+        </g>
+      )}
+
+      {/* Activation control for owned lines in sneaky tricks phase */}
+      {isOwnedByCurrentPlayer && isSneakyTricks && viewMode === "normal" && (
+        <g className="activation-button" opacity="0.9">
+          <circle
+            cx={midX}
+            cy={midY}
+            r="12"
+            fill={owner.color}
+            stroke="white"
+            strokeWidth="2"
+            style={{ cursor: "pointer" }}
+            onClick={
+              displayActive ? handleDeactivateClick : handleActivateClick
+            }
+            onMouseEnter={handleActivationHover}
+            onMouseLeave={onLeave}
+          />
+          {/* Open circuit indicator - diagonal line when INACTIVE (closed) */}
+          {!displayActive && (
+            <path
+              d={`M ${midX - 8} ${midY - 8} L ${midX + 8} ${midY + 8}`}
+              stroke="white"
+              strokeWidth="2"
+              strokeLinecap="round"
+              pointerEvents="none"
+            />
+          )}
         </g>
       )}
     </g>

--- a/front_end/src/components/Game/TransmissionLine.tsx
+++ b/front_end/src/components/Game/TransmissionLine.tsx
@@ -117,6 +117,8 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
     event.stopPropagation();
     if (onActivate) {
       onActivate(line.id);
+      // If we're currently hovering over this line, update the hover data
+      // This will be handled by the parent component's state update
     }
   };
 
@@ -124,6 +126,8 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
     event.stopPropagation();
     if (onDeactivate) {
       onDeactivate(line.id);
+      // If we're currently hovering over this line, update the hover data
+      // This will be handled by the parent component's state update
     }
   };
 
@@ -185,29 +189,34 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
   const midX = (fromX + toX) / 2;
   const midY = (fromY + toY) / 2;
 
+  const lineAngle = Math.atan2(baseVector.y, baseVector.x);
+  const perpAngle = lineAngle + Math.PI / 2; // Perpendicular angle
+  const perpVector: Point = {x: Math.cos(perpAngle), y: Math.sin(perpAngle)}
+
   // Add slight curve by offsetting the middle point
   const curveOffset = 0.1;
   const offsetX = baseVector.y * curveOffset;
   const offsetY = -baseVector.x * curveOffset;
 
-  const mid_point = { x: midX + offsetX, y: midY + offsetY };
+  const midPoint: Point = { x: midX + offsetX, y: midY + offsetY };
 
-  const pathData = `M ${fromX} ${fromY} Q ${mid_point.x} ${
-    mid_point.y
+  const pathData = `M ${fromX} ${fromY} Q ${midPoint.x} ${
+    midPoint.y
   } ${toX} ${toY}`;
 
   // Find the true middle of the curved line
-  const curveMidX = (mid_point.x + midX) / 2;
-  const curveMidY = (mid_point.y + midY) / 2;
-  const curveMid = { x: curveMidX, y: curveMidY };
+  const curveMidX = (midPoint.x + midX) / 2;
+  const curveMidY = (midPoint.y + midY) / 2;
+  const curveMid: Point = { x: curveMidX, y: curveMidY };
+
+  const buttonPoint: Point = { x: curveMid.x + perpVector.x * -15, y: curveMid.y + perpVector.y * -15};
 
   // Calculate line for open circuit indicator
-  const lineAngle = Math.atan2(baseVector.y, baseVector.x);
-  const perpAngle = lineAngle + Math.PI / 2; // Perpendicular angle
-  const perpX1 = curveMidX + Math.cos(perpAngle) * 8;
-  const perpY1 = curveMidY + Math.sin(perpAngle) * 8;
-  const perpX2 = curveMidX - Math.cos(perpAngle) * 8;
-  const perpY2 = curveMidY - Math.sin(perpAngle) * 8;
+
+  const perpX1 = curveMidX + perpVector.x * 8;
+  const perpY1 = curveMidY + perpVector.y * 8;
+  const perpX2 = curveMidX - perpVector.x * 8;
+  const perpY2 = curveMidY - perpVector.y * 8;
 
   // Check if player can afford this line
   const canAfford =
@@ -288,8 +297,8 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
       {isPurchasable && viewMode === "normal" && (
         <g className="purchase-button" opacity="0.9">
           <circle
-            cx={midX}
-            cy={midY}
+            cx={buttonPoint.x}
+            cy={buttonPoint.y}
             r="10"
             fill={canAfford ? "#22c55e" : "#9ca3af"}
             stroke="white"
@@ -314,8 +323,8 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
             onMouseLeave={onLeave}
           />
           <text
-            x={midX}
-            y={midY + 4}
+            x={buttonPoint.x}
+            y={buttonPoint.y + 4}
             textAnchor="middle"
             fontSize="10"
             fill="white"
@@ -331,10 +340,10 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
       {isOwnedByCurrentPlayer && isSneakyTricks && viewMode === "normal" && (
         <g className="activation-button" opacity="0.9">
           <circle
-            cx={midX}
-            cy={midY}
-            r="12"
-            fill={owner.color}
+            cx={buttonPoint.x}
+            cy={buttonPoint.y}
+            r="10"
+            fill={displayActive ? "#22c55e" : "#9ca3af"}
             stroke="white"
             strokeWidth="2"
             style={{ cursor: "pointer" }}
@@ -344,6 +353,32 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
             onMouseEnter={handleActivationHover}
             onMouseLeave={onLeave}
           />
+          {/* Tick for ACTIVE, cross for INACTIVE */}
+          {displayActive ? (
+            <text
+              x={buttonPoint.x}
+              y={buttonPoint.y + 4}
+              textAnchor="middle"
+              fontSize="10"
+              fill="white"
+              pointerEvents="none"
+              fontWeight="bold"
+            >
+              ✓
+            </text>
+          ) : (
+            <text
+              x={buttonPoint.x}
+              y={buttonPoint.y + 4}
+              textAnchor="middle"
+              fontSize="10"
+              fill="white"
+              pointerEvents="none"
+              fontWeight="bold"
+            >
+              ✗
+            </text>
+          )}
         </g>
       )}
     </g>

--- a/front_end/src/components/Game/TransmissionLine.tsx
+++ b/front_end/src/components/Game/TransmissionLine.tsx
@@ -88,22 +88,6 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
     );
   };
 
-  const handlePurchaseButtonHover = (event: React.MouseEvent) => {
-    event.stopPropagation();
-    onHover(
-      {
-        type: "line",
-        id: line.id,
-        title: `Purchase Line${line.id}`,
-        data: {
-          Cost: `$${line.minimum_acquisition_price.toLocaleString()}`,
-          Action: "Click to purchase this transmission line",
-        },
-      },
-      event,
-    );
-  };
-
   const handleActivationHover = (event: React.MouseEvent) => {
     event.stopPropagation();
     onHover(

--- a/front_end/src/components/Game/TransmissionLine.tsx
+++ b/front_end/src/components/Game/TransmissionLine.tsx
@@ -4,6 +4,7 @@ import {
   BusWithDisplayCoords,
   HoverableElement,
   Player,
+  Point,
   TransmissionLine,
 } from "@/types/game";
 import React from "react";
@@ -57,7 +58,7 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
   if (!fromBus || !toBus) return null;
 
   // Use provided isActive prop if available, otherwise fall back to line.is_open
-  const displayActive = isActive !== undefined ? isActive : line.is_open;
+  const displayActive = isActive !== undefined ? isActive : line.is_active;
 
   const getLineData = () => {
     const data: { [key: string]: string } = {
@@ -70,7 +71,7 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
         `$${line.minimum_acquisition_price.toLocaleString()}`;
     }
 
-    data["Status"] = displayActive ? "OPEN" : "CLOSED";
+    data["Status"] = displayActive ? "CLOSED" : "OPEN";
 
     return data;
   };
@@ -82,6 +83,40 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
         id: line.id,
         title: `Line${line.id}`,
         data: getLineData(),
+      },
+      event,
+    );
+  };
+
+  const handlePurchaseButtonHover = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    onHover(
+      {
+        type: "line",
+        id: line.id,
+        title: `Purchase Line${line.id}`,
+        data: {
+          Cost: `$${line.minimum_acquisition_price.toLocaleString()}`,
+          Action: "Click to purchase this transmission line",
+        },
+      },
+      event,
+    );
+  };
+
+  const handleActivationHover = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    onHover(
+      {
+        type: "line",
+        id: line.id,
+        title: `Line${line.id}`,
+        data: {
+          ...getLineData(),
+          Action: displayActive
+            ? "Click to open (deactivate) this line"
+            : "Click to close (activate) this line",
+        },
       },
       event,
     );
@@ -108,26 +143,8 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
     }
   };
 
-  const handleActivationHover = (event: React.MouseEvent) => {
-    event.stopPropagation();
-    onHover(
-      {
-        type: "line",
-        id: line.id,
-        title: `Line${line.id}`,
-        data: {
-          ...getLineData(),
-          Action: displayActive
-            ? "Click to close (deactivate) this line"
-            : "Click to open (activate) this line",
-        },
-      },
-      event,
-    );
-  };
-
   const getLineColor = () => {
-    if (displayActive) {
+    if (!displayActive) {
       // Deactivate color similar to the Python implementation
       return adjustColor(owner.color, 0.5);
     }
@@ -136,23 +153,13 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
 
   // Helper function to create arrow path for flow direction along the curved line
   const getArrowPath = (
-    midX: number,
-    midY: number,
-    fromX: number,
-    fromY: number,
-    toX: number,
-    toY: number,
+    vector: Point,
+    curveMid: Point,
     flowForward: boolean,
   ) => {
-    // Calculate the control point for the quadratic Bézier curve (same as the line's curve)
-    const vector = { x: toX - fromX, y: toY - fromY };
-    const trueMidX = (fromX + toX) / 2;
-    const trueMidY = (fromY + toY) / 2;
-
-    const arrowX = (trueMidX + midX) / 2;
-    const arrowY = (trueMidY + midY) / 2;
-
     const angle = Math.atan2(vector.y, vector.x) + (flowForward ? 0 : Math.PI); // +180 degrees to face flow direction
+    const arrowX = curveMid.x;
+    const arrowY = curveMid.y;
 
     const arrowSize = 22;
 
@@ -190,14 +197,14 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
   const toX = toBus.display_position.x || toBus.x;
   const toY = toBus.display_position.y || toBus.y;
 
-  const vector = { x: toX - fromX, y: toY - fromY };
+  const baseVector = { x: toX - fromX, y: toY - fromY };
   const midX = (fromX + toX) / 2;
   const midY = (fromY + toY) / 2;
 
   // Add slight curve by offsetting the middle point
   const curveOffset = 0.1;
-  const offsetX = vector.y * curveOffset;
-  const offsetY = -vector.x * curveOffset;
+  const offsetX = baseVector.y * curveOffset;
+  const offsetY = -baseVector.x * curveOffset;
 
   const mid_point = { x: midX + offsetX, y: midY + offsetY };
 
@@ -205,26 +212,23 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
     mid_point.y
   } ${toX} ${toY}`;
 
+  // Find the true middle of the curved line
+  const curveMidX = (mid_point.x + midX) / 2;
+  const curveMidY = (mid_point.y + midY) / 2;
+  const curveMid = { x: curveMidX, y: curveMidY };
+
+  // Calculate line for open circuit indicator
+  const lineAngle = Math.atan2(baseVector.y, baseVector.x);
+  const perpAngle = lineAngle + Math.PI / 2; // Perpendicular angle
+  const perpX1 = curveMidX + Math.cos(perpAngle) * 8;
+  const perpY1 = curveMidY + Math.sin(perpAngle) * 8;
+  const perpX2 = curveMidX - Math.cos(perpAngle) * 8;
+  const perpY2 = curveMidY - Math.sin(perpAngle) * 8;
+
   // Check if player can afford this line
   const canAfford =
     !isPurchasable ||
     (onPurchase && line.minimum_acquisition_price <= playerMoney);
-
-  const handlePurchaseButtonHover = (event: React.MouseEvent) => {
-    event.stopPropagation();
-    onHover(
-      {
-        type: "line",
-        id: line.id,
-        title: `Purchase Line${line.id}`,
-        data: {
-          Cost: `$${line.minimum_acquisition_price.toLocaleString()}`,
-          Action: "Click to purchase this transmission line",
-        },
-      },
-      event,
-    );
-  };
 
   // Calculate flow animation properties using actual power from market summary
   const flowValue = actualFlow ?? 0;
@@ -274,18 +278,21 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
         pointerEvents="none"
       />
 
+      {/* Open circuit indicator - thick gray perpendicular line when line is OPEN */}
+      {!displayActive && viewMode === "normal" && (
+        <path
+          d={`M ${perpX2} ${perpY2} L ${perpX1} ${perpY1}`}
+          stroke="#6b7280"
+          strokeWidth={4}
+          strokeLinecap="round"
+          pointerEvents="none"
+        />
+      )}
+
       {/* Flow direction indicator (arrow) - only show in market view with significant flow */}
       {viewMode === "market" && showFlowAnimation && flowRatio > 0.1 && (
         <path
-          d={getArrowPath(
-            mid_point.x,
-            mid_point.y,
-            fromX,
-            fromY,
-            toX,
-            toY,
-            flowForward,
-          )}
+          d={getArrowPath(baseVector, curveMid, flowForward)}
           stroke="#000000" // Dark gray color
           strokeWidth={1}
           fill="#7a7a7a" // Dark gray color
@@ -305,7 +312,21 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
             strokeWidth="2"
             style={{ cursor: canAfford ? "pointer" : "not-allowed" }}
             onClick={canAfford ? handlePurchaseClick : undefined}
-            onMouseEnter={handlePurchaseButtonHover}
+            onMouseEnter={(e) => {
+              e.stopPropagation();
+              onHover(
+                {
+                  type: "line",
+                  id: line.id,
+                  title: `Purchase Line${line.id}`,
+                  data: {
+                    Cost: `$${line.minimum_acquisition_price.toLocaleString()}`,
+                    Action: "Click to purchase this transmission line",
+                  },
+                },
+                e,
+              );
+            }}
             onMouseLeave={onLeave}
           />
           <text
@@ -339,16 +360,6 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
             onMouseEnter={handleActivationHover}
             onMouseLeave={onLeave}
           />
-          {/* Open circuit indicator - diagonal line when INACTIVE (closed) */}
-          {!displayActive && (
-            <path
-              d={`M ${midX - 8} ${midY - 8} L ${midX + 8} ${midY + 8}`}
-              stroke="white"
-              strokeWidth="2"
-              strokeLinecap="round"
-              pointerEvents="none"
-            />
-          )}
         </g>
       )}
     </g>

--- a/front_end/src/lib/gameWebSocket.ts
+++ b/front_end/src/lib/gameWebSocket.ts
@@ -201,11 +201,11 @@ export class GameWebSocketClient {
     });
   }
 
-  public operateLine(transmissionId: string, action: "open" | "close"): void {
-    this.send("operate_line_request", {
-      transmission_id: transmissionId,
-      action: action,
-    });
+  public activationUpdate(activationUpdates: {
+    line_activation?: Record<number, boolean>;
+    asset_activation?: Record<number, boolean>;
+  }): void {
+    this.send("activation_update_request", activationUpdates);
   }
 
   public endTurn(): void {

--- a/front_end/src/types/game.ts
+++ b/front_end/src/types/game.ts
@@ -2,7 +2,6 @@ export interface Bus {
   id: number;
   x: number;
   y: number;
-  player_id: number;
   max_lines: number;
   max_assets: number;
   color: string;


### PR DESCRIPTION
Note that this can feel a bit weird when playing local multiplayer because your actions disappear when you finish your turn and then re-appear when everyone has finished. Perhaps in future we can have logic that decides to commit the changes directly for local multiplayer and defers the commit until the end of the entire phase for online multiplayer.
<img width="623" height="590" alt="Screenshot from 2026-04-11 16-39-26" src="https://github.com/user-attachments/assets/18647709-5477-4a67-a33f-9f2133e661db" />
