### PR TITLE
Feature/add bids to pending state

### DIFF
--- a/back_end/src/app/server.py
+++ b/back_end/src/app/server.py
@@ -176,16 +176,10 @@ async def list_games():
             try:
                 game_state = game_repo.get_game_state(GameId(int(game_id)))
                 player_names = [p.name for p in game_state.players.human_players]
-                games_info.append({
-                    "game_id": str(game_id),
-                    "players": player_names
-                })
+                games_info.append({"game_id": str(game_id), "players": player_names})
             except Exception:
                 # If can't load game state, just include id
-                games_info.append({
-                    "game_id": str(game_id),
-                    "players": []
-                })
+                games_info.append({"game_id": str(game_id), "players": []})
         return {"games": games_info, "count": len(games_info)}
     except Exception as e:
         log_exception_with_traceback(f"Error listing games: {e}", e)

--- a/back_end/src/app/tools/reduce_message.py
+++ b/back_end/src/app/tools/reduce_message.py
@@ -2,6 +2,7 @@ from dataclasses import replace
 from typing import Protocol, runtime_checkable
 
 import pandas as pd
+from back_end.src.models.pending_state import PendingState
 
 from src.engine.finance import FinanceCalculator
 from src.models.game_state import GameState
@@ -23,7 +24,7 @@ def reduce_message[T: Message](msg: T) -> T:
 
 def reduce_game_state(game_state: GameState) -> GameState:
     """
-    Makes the game state more compact before passing to the front end
+    Makes the game state more compact before passing to the front end. Also hide the pending state as it is private.
     """
     if game_state.market_coupling_result is None:
         return game_state
@@ -33,15 +34,15 @@ def reduce_game_state(game_state: GameState) -> GameState:
     line_results = {line: reduce_one_line(game_state=game_state, coupling_result=game_state.market_coupling_result, line_id=line) for line in game_state.transmission.transmission_ids}
     pnl = FinanceCalculator.compute_cashflows_after_power_delivery(game_state=game_state, market_coupling_result=game_state.market_coupling_result)
     market_summary = MarketCouplingSummary(bus_results=bus_results, line_results=line_results, pnl=pnl)
-    return replace(game_state, market_summary=market_summary, market_coupling_result=None)
+    return replace(game_state, market_summary=market_summary, market_coupling_result=None, pending_state=PendingState())
 
 
 def reduce_one_line(game_state: GameState, coupling_result: MarketCouplingResult, line_id: TransmissionId) -> pd.DataFrame:
     line = game_state.transmission[line_id]
 
     flow = float(coupling_result.transmission_flows[line_id].sum())
-    b1_price = float(coupling_result.bus_prices.loc[0, line.bus1])
-    b2_price = float(coupling_result.bus_prices.loc[0, line.bus2])
+    b1_price = float(coupling_result.bus_prices.loc[0, line.bus1])  # type: ignore
+    b2_price = float(coupling_result.bus_prices.loc[0, line.bus2])  # type: ignore
     if flow >= 0 - 1e-3:
         direction = f"{line.bus1} -> {line.bus2}"
         price_spread = b2_price - b1_price

--- a/back_end/src/app/tools/reduce_message.py
+++ b/back_end/src/app/tools/reduce_message.py
@@ -2,13 +2,13 @@ from dataclasses import replace
 from typing import Protocol, runtime_checkable
 
 import pandas as pd
-from src.models.pending_state import PendingState
 
 from src.engine.finance import FinanceCalculator
 from src.models.game_state import GameState
 from src.models.ids import AssetId, BusId, TransmissionId
 from src.models.market_coupling_result import MarketCouplingResult, MarketCouplingSummary
 from src.models.message import Message
+from src.models.pending_state import PendingState
 
 
 @runtime_checkable

--- a/back_end/src/app/tools/reduce_message.py
+++ b/back_end/src/app/tools/reduce_message.py
@@ -2,7 +2,7 @@ from dataclasses import replace
 from typing import Protocol, runtime_checkable
 
 import pandas as pd
-from back_end.src.models.pending_state import PendingState
+from src.models.pending_state import PendingState
 
 from src.engine.finance import FinanceCalculator
 from src.models.game_state import GameState

--- a/back_end/src/engine/engine.py
+++ b/back_end/src/engine/engine.py
@@ -114,7 +114,7 @@ class Engine:
 
         _, updated_asset_bids = cls._validate_update_batch_bid(gs=game_state, msg=msg)
 
-        new_assets = game_state.assets.batch_update_bid_price(asset_ids=list(updated_asset_bids.keys()), bid_prices=list(updated_asset_bids.values()))
+        new_assets = game_state.assets.update_bids(asset_ids=list(updated_asset_bids.keys()), bid_prices=list(updated_asset_bids.values()))
         new_game_state = game_state.update(new_assets)
 
         response = UpdateBatchBidResponse(

--- a/back_end/src/engine/engine.py
+++ b/back_end/src/engine/engine.py
@@ -20,7 +20,6 @@ from src.models.message import (
     PlayerNotInTurn,
     PlayerToGameMessage,
     ToGameMessage,
-    UpdateBatchBidResponse,
     UpdateBatchBidsRequest,
 )
 from src.models.pending_state import PendingState
@@ -247,50 +246,3 @@ class Engine:
             )
 
         return new_game_state, msgs
-
-    @classmethod
-    def _validate_update_batch_bid(cls, gs: GameState, msg: UpdateBatchBidsRequest) -> tuple[list[Message], dict[AssetId, float]]:
-        """Validates the batch bid update request and returns a list of messages for any failed validations, as well as a dict of accepted bids with their potentially adjusted bid prices."""
-
-        def make_failed_response(failed_message: str) -> list[Message]:
-            failed_response = UpdateBatchBidResponse(
-                game_id=gs.game_id,
-                player_id=msg.player_id,
-                success=False,
-                message=failed_message,
-            )
-            return [failed_response]
-
-        def make_success_response_with_warning(warning_message: str) -> list[Message]:
-            success_with_warning = UpdateBatchBidResponse(
-                game_id=gs.game_id,
-                player_id=msg.player_id,
-                success=True,
-                message=warning_message,
-            )
-            return [success_with_warning]
-
-        player = gs.players[msg.player_id]
-        min_bid = gs.game_settings.min_bid_price
-        max_bid = gs.game_settings.max_bid_price
-
-        responses: list[Message] = []
-        accepted_bids = dict(msg.bids)
-
-        for asset_id, bid_price in msg.bids.items():
-            if asset_id not in gs.assets.asset_ids:
-                responses += make_failed_response(f"Asset {asset_id} does not exist.")
-                accepted_bids.pop(asset_id)
-
-            asset = gs.assets[asset_id]
-            if asset.owner_player != player.id:
-                responses += make_failed_response(f"Player {player.id} cannot bid on asset {asset_id} as they do not own it.")
-                accepted_bids.pop(asset_id)
-
-            if not (min_bid <= bid_price <= max_bid):
-                accepted_bids[asset_id] = max(min(bid_price, max_bid), min_bid)
-                responses += make_success_response_with_warning(
-                    f"Bid price {bid_price} for asset {asset_id} is not within the allowed range [{min_bid}, {max_bid}].It has been adjusted to {accepted_bids[asset_id]}."
-                )
-
-        return responses, accepted_bids

--- a/back_end/src/engine/engine.py
+++ b/back_end/src/engine/engine.py
@@ -105,25 +105,9 @@ class Engine:
         game_state: GameState,
         msg: UpdateBatchBidsRequest,
     ) -> tuple[GameState, list[Message]]:
-        if game_state.phase != Phase.BIDDING:
-            response = msg.make_response(
-                success=False,
-                message=f"You can only update bids during the {Phase.BIDDING.nice_name} phase",
-            )
-            return game_state, [response]
-
-        _, updated_asset_bids = cls._validate_update_batch_bid(gs=game_state, msg=msg)
-
-        new_assets = game_state.assets.update_bids(asset_ids=list(updated_asset_bids.keys()), bid_prices=list(updated_asset_bids.values()))
-        new_game_state = game_state.update(new_assets)
-
-        response = UpdateBatchBidResponse(
-            game_id=msg.game_id,
-            player_id=msg.player_id,
-            success=True,
-            message=f"Player {msg.player_id} successfully updated batch bids.",
-        )
-
+        pending_state = game_state.pending_state.update(PendingState(bids=msg.bids))
+        new_game_state = game_state.update(pending_state)
+        response = Ack(game_id=game_state.game_id, player_id=msg.player_id)
         return new_game_state, [response]
 
     @classmethod

--- a/back_end/src/engine/engine.py
+++ b/back_end/src/engine/engine.py
@@ -22,8 +22,6 @@ from src.models.message import (
     ToGameMessage,
     UpdateBatchBidResponse,
     UpdateBatchBidsRequest,
-    UpdateBidRequest,
-    UpdateBidResponse,
 )
 from src.models.pending_state import PendingState
 
@@ -47,8 +45,6 @@ class Engine:
         match msg:
             case ConcludePhase():
                 return cls.handle_new_phase_message(game_state=game_state, msg=msg)
-            case UpdateBidRequest():
-                return cls.handle_update_bid_message(game_state=game_state, msg=msg)
             case UpdateBatchBidsRequest():
                 return cls.handle_update_batch_bid_message(game_state=game_state, msg=msg)
             case ActivationUpdateRequest():
@@ -68,7 +64,6 @@ class Engine:
         game_state: GameState,
         msg: ToGameMessage,
     ) -> tuple[GameState, list[Message]] | None:
-
         if not isinstance(msg, PlayerToGameMessage):
             return None
 
@@ -76,11 +71,7 @@ class Engine:
         if game_state.players[requesting_player_id].is_having_turn:
             return None
         else:
-            return game_state, [PlayerNotInTurn(
-                player_id=requesting_player_id,
-                game_id=game_state.game_id,
-                message=f"Player {requesting_player_id} cannot play when it is not their turn."
-            )]
+            return game_state, [PlayerNotInTurn(player_id=requesting_player_id, game_id=game_state.game_id, message=f"Player {requesting_player_id} cannot play when it is not their turn.")]
 
     @classmethod
     def handle_new_phase_message(
@@ -121,10 +112,9 @@ class Engine:
             )
             return game_state, [response]
 
-        list_responses, updated_asset_bids = cls._validate_update_batch_bid(gs=game_state, msg=msg)
+        _, updated_asset_bids = cls._validate_update_batch_bid(gs=game_state, msg=msg)
 
-        new_assets = game_state.assets.batch_update_bid_price(asset_ids=list(updated_asset_bids.keys()),
-                                                              bid_prices=list(updated_asset_bids.values()))
+        new_assets = game_state.assets.batch_update_bid_price(asset_ids=list(updated_asset_bids.keys()), bid_prices=list(updated_asset_bids.values()))
         new_game_state = game_state.update(new_assets)
 
         response = UpdateBatchBidResponse(
@@ -132,36 +122,6 @@ class Engine:
             player_id=msg.player_id,
             success=True,
             message=f"Player {msg.player_id} successfully updated batch bids.",
-        )
-
-        return new_game_state, [response]
-
-    @classmethod
-    def handle_update_bid_message(
-        cls,
-        game_state: GameState,
-        msg: UpdateBidRequest,
-    ) -> tuple[GameState, list[Message]]:
-        if game_state.phase != Phase.BIDDING:
-            response = msg.make_response(
-                success=False,
-                message=f"You can only update bids during the {Phase.BIDDING.nice_name} phase",
-            )
-            return game_state, [response]
-
-        list_failed_response = cls._validate_update_bid(gs=game_state, msg=msg)
-        if list_failed_response:
-            return game_state, cast(list[Message], list_failed_response)
-
-        new_assets = game_state.assets.update_bid_price(asset_id=msg.asset_id, bid_price=msg.bid_price)
-        new_game_state = game_state.update(new_assets)
-
-        response = UpdateBidResponse(
-            game_id=msg.game_id,
-            player_id=msg.player_id,
-            success=True,
-            message=f"Player {msg.player_id} successfully updated bid for asset {msg.asset_id} to {msg.bid_price}.",
-            asset_id=msg.asset_id,
         )
 
         return new_game_state, [response]
@@ -305,36 +265,9 @@ class Engine:
         return new_game_state, msgs
 
     @classmethod
-    def _validate_update_bid(cls, gs: GameState, msg: UpdateBidRequest) -> list[Message]:
-        def make_failed_response(failed_message: str) -> list[Message]:
-            failed_response = UpdateBidResponse(
-                game_id=gs.game_id,
-                player_id=msg.player_id,
-                success=False,
-                message=failed_message,
-                asset_id=msg.asset_id,
-            )
-            return [failed_response]
-
-        if msg.asset_id not in gs.assets.asset_ids:
-            return make_failed_response("Asset does not exist.")
-
-        player = gs.players[msg.player_id]
-        asset = gs.assets[msg.asset_id]
-        min_bid = gs.game_settings.min_bid_price
-        max_bid = gs.game_settings.max_bid_price
-
-        if player.id != asset.owner_player:
-            return make_failed_response(f"Player {player.id} cannot bid on asset {asset.id} as they do not own it.")
-
-        if not (min_bid <= msg.bid_price <= max_bid):
-            return make_failed_response(f"Bid price {msg.bid_price} is not within the allowed range [{min_bid}, {max_bid}].")
-
-        return []
-
-    @classmethod
     def _validate_update_batch_bid(cls, gs: GameState, msg: UpdateBatchBidsRequest) -> tuple[list[Message], dict[AssetId, float]]:
         """Validates the batch bid update request and returns a list of messages for any failed validations, as well as a dict of accepted bids with their potentially adjusted bid prices."""
+
         def make_failed_response(failed_message: str) -> list[Message]:
             failed_response = UpdateBatchBidResponse(
                 game_id=gs.game_id,
@@ -373,8 +306,7 @@ class Engine:
             if not (min_bid <= bid_price <= max_bid):
                 accepted_bids[asset_id] = max(min(bid_price, max_bid), min_bid)
                 responses += make_success_response_with_warning(
-                    f"Bid price {bid_price} for asset {asset_id} is not within the allowed range [{min_bid}, {max_bid}]."
-                    f"It has been adjusted to {accepted_bids[asset_id]}."
+                    f"Bid price {bid_price} for asset {asset_id} is not within the allowed range [{min_bid}, {max_bid}].It has been adjusted to {accepted_bids[asset_id]}."
                 )
 
         return responses, accepted_bids

--- a/back_end/src/engine/grid_expansion.py
+++ b/back_end/src/engine/grid_expansion.py
@@ -11,7 +11,6 @@ from src.tools.random_choice import sample_boolean
 
 
 class GridExpansion:
-
     @classmethod
     def build_grid_elements_for_new_round(cls, game_state: GameState) -> tuple[GameState, list[AssetBuiltMessage | TransmissionBuiltMessage]]:
         new_game_state, build_transmission_msgs = cls.try_build_transmission(game_state)
@@ -34,12 +33,7 @@ class GridExpansion:
 
         asset_maker = LoadMaker() if cls._check_system_adequacy(game_state) else GeneratorMaker()
 
-        new_asset = asset_maker.make_one(
-            asset_id=AssetId(game_state.assets.next_id()),
-            bus_id=socket_manager.get_bus_with_free_socket(use=True),
-            current_round=game_state.game_round,
-            **kwargs
-        )
+        new_asset = asset_maker.make_one(asset_id=AssetId(game_state.assets.next_id()), bus_id=socket_manager.get_bus_with_free_socket(use=True), current_round=game_state.game_round, **kwargs)
         new_game_state = game_state.update(game_state.assets + new_asset)
 
         msgs = [
@@ -60,16 +54,10 @@ class GridExpansion:
 
     @classmethod
     def _create_asset_socket_manager(cls, game_state: GameState) -> BusSocketManager:
-        available_bus_sockets = {
-            bus.id: bus.max_assets - len(game_state.assets.get_all_assets_at_bus(bus.id))
-            for bus in game_state.buses
-        }
+        available_bus_sockets = {bus.id: bus.max_assets - len(game_state.assets.get_all_assets_at_bus(bus.id)) for bus in game_state.buses}
         return BusSocketManager(starting_sockets=available_bus_sockets)
 
     @classmethod
     def _create_transmission_socket_manager(cls, game_state: GameState) -> BusSocketManager:
-        available_bus_sockets = {
-            bus.id: bus.max_lines - len(game_state.transmission.get_all_at_bus(bus.id))
-            for bus in game_state.buses
-        }
+        available_bus_sockets = {bus.id: bus.max_lines - len(game_state.transmission.get_all_at_bus(bus.id)) for bus in game_state.buses}
         return BusSocketManager(starting_sockets=available_bus_sockets)

--- a/back_end/src/engine/market_coupling.py
+++ b/back_end/src/engine/market_coupling.py
@@ -103,9 +103,7 @@ class MarketCouplingCalculator:
                 game_state=game_state,
                 message=f"PyPSA optimization failed with status: {status}. Please check the network setup.",
             )
-        logging.getLogger(__name__).info(
-            f"Optimization successfully ended with status: {status}."
-        )
+        logging.getLogger(__name__).info(f"Optimization successfully ended with status: {status}.")
         return
 
     @classmethod

--- a/back_end/src/models/assets.py
+++ b/back_end/src/models/assets.py
@@ -125,14 +125,11 @@ class AssetRepo(LdcRepo[AssetInfo]):
         df.loc[asset_id, "is_for_sale"] = False
         return self.update_frame(df)
 
-    def update_bid_price(self, asset_id: AssetId, bid_price: float) -> "AssetRepo":
+    def update_bids(self, bids: MappingProxyType[AssetId, float]) -> "AssetRepo":
         df = self.df
-        df.loc[asset_id, "bid_price"] = bid_price
-        return self.update_frame(df)
-
-    def batch_update_bid_price(self, asset_ids: list[AssetId], bid_prices: list[float]) -> "AssetRepo":
-        df = self.df
-        df.loc[asset_ids, "bid_price"] = bid_prices
+        asset_ids = list(bids.keys())
+        prices = list(bids.values())
+        df.loc[asset_ids, "bid_price"] = prices
         return self.update_frame(df)
 
     def _decrease_health(self, asset_id: AssetId) -> "AssetRepo":
@@ -154,16 +151,6 @@ class AssetRepo(LdcRepo[AssetInfo]):
         assert not self.df.loc[asset_id, "is_freezer"], "Only non-freezer assets can wear out"
         return self._decrease_health(asset_id)
 
-    def deactivate(self, asset_id: AssetId) -> "AssetRepo":
-        df = self.df
-        df.loc[asset_id, "is_active"] = False
-        return self.update_frame(df)
-
-    def activate(self, asset_id: AssetId) -> "AssetRepo":
-        df = self.df
-        df.loc[asset_id, "is_active"] = True
-        return self.update_frame(df)
-
     def batch_deactivate(self, asset_ids: list[AssetId]) -> "AssetRepo":
         df = self.df
         df.loc[asset_ids, "is_active"] = False
@@ -176,7 +163,6 @@ class AssetRepo(LdcRepo[AssetInfo]):
         df.loc[actives, "is_active"] = True
         df.loc[inactives, "is_active"] = False
         return self.update_frame(df)
-
 
     # DELETE
     def delete_for_player(self, player_id: PlayerId) -> "AssetRepo":

--- a/back_end/src/models/buses.py
+++ b/back_end/src/models/buses.py
@@ -43,6 +43,7 @@ class BusRepo(LdcRepo[Bus]):
     def bus_ids(self) -> list[BusId]:
         return [BusId(x) for x in self.df.index.tolist()]
 
+
 class BusFullException(Exception):
     # You have to sit on the bus driver's lap
     pass

--- a/back_end/src/models/game_state.py
+++ b/back_end/src/models/game_state.py
@@ -15,6 +15,7 @@ from src.tools.serialization import simplify_type, un_simplify_type
 
 __all__ = ["Phase", "GameState"]
 
+
 class Phase(IntEnum):
     CONSTRUCTION = 0
     SNEAKY_TRICKS = 1
@@ -66,8 +67,15 @@ class GameState:
         return self.players.get_currently_playing().player_ids
 
     def commit_pending_state(self) -> Self:
-        assets = self.assets.update_activations(self.pending_state.asset_activation)
-        transmission = self.transmission.update_activations(self.pending_state.line_activation)
+        assets = self.assets
+        transmission = self.transmission
+        if len(self.pending_state.asset_activation):
+            assets = assets.update_activations(self.pending_state.asset_activation)
+        if len(self.pending_state.line_activation):
+            transmission = transmission.update_activations(self.pending_state.line_activation)
+        if len(self.pending_state.bids):
+            assets = assets.update_bids(self.pending_state.bids)
+
         return self.update(assets, transmission, PendingState())
 
     def add_asset(self, asset: AssetInfo) -> Self:
@@ -121,7 +129,6 @@ class GameState:
 
         return replace(self, **map_new_attributes)  # type: ignore[arg-type]
 
-
     def to_simple_dict(self) -> dict:
         return {
             "game_id": self.game_id.as_int(),
@@ -134,7 +141,7 @@ class GameState:
             "market_coupling_result": (self.market_coupling_result.to_simple_dict() if self.market_coupling_result else None),
             "market_summary": (self.market_summary.to_simple_dict() if self.market_summary else None),
             "game_round": self.game_round,
-            "pending_state": self.pending_state.to_simple_dict()
+            "pending_state": self.pending_state.to_simple_dict(),
         }
 
     @classmethod
@@ -144,7 +151,6 @@ class GameState:
         attr_to_type["market_coupling_result"] = MarketCouplingResult
         type_to_attr: dict[type[GameStateAttributes], str] = {v: k for k, v in attr_to_type.items()}
         return type_to_attr
-
 
     @classmethod
     def from_simple_dict(cls, simple_dict: dict) -> Self:
@@ -159,5 +165,5 @@ class GameState:
             market_coupling_result=(MarketCouplingResult.from_simple_dict(simple_dict["market_coupling_result"]) if simple_dict.get("market_coupling_result") else None),
             market_summary=(MarketCouplingSummary.from_simple_dict(simple_dict["market_summary"]) if simple_dict.get("market_summary") else None),
             game_round=Round(simple_dict["game_round"]),
-            pending_state=PendingState.from_simple_dict(simple_dict["pending_state"])
+            pending_state=PendingState.from_simple_dict(simple_dict["pending_state"]),
         )

--- a/back_end/src/models/game_state.py
+++ b/back_end/src/models/game_state.py
@@ -56,7 +56,7 @@ class GameState:
     market_coupling_result: MarketCouplingResult | None
     market_summary: MarketCouplingSummary | None = None
     game_round: Round = Round(1)
-    pending_state: PendingState = PendingState()
+    pending_state: PendingState = PendingState()  # A record of actions that cannot be made public yet
 
     def __post_init__(self) -> None:
         assert isinstance(self.game_round, Round), f"game_round must be of type Round. Got {type(self.game_round)}"

--- a/back_end/src/models/message.py
+++ b/back_end/src/models/message.py
@@ -85,31 +85,14 @@ class PlayerNotInTurn(GameToPlayerMessage):
     pass
 
 @dataclass(frozen=True)
-class UpdateBidResponse(GameToPlayerMessage):
-    success: bool
-    asset_id: AssetId
+class Ack(GameToPlayerMessage):
+    message: str = "👍"
 
 @dataclass(frozen=True)
 class Ack(GameToPlayerMessage):
     message: str = "👍"
 
 
-@dataclass(frozen=True)
-class UpdateBidRequest(PlayerToGameMessage):
-    asset_id: AssetId
-    bid_price: float
-
-    def make_response(self, success: bool, message: str) -> UpdateBidResponse:
-        return UpdateBidResponse(
-            game_id=self.game_id,
-            player_id=self.player_id,
-            asset_id=self.asset_id,
-            success=success,
-            message=message,
-        )
-
-
-# update_batch_bids_request
 @dataclass(frozen=True)
 class UpdateBatchBidResponse(GameToPlayerMessage):
     success: bool

--- a/back_end/src/models/message.py
+++ b/back_end/src/models/message.py
@@ -80,13 +80,16 @@ class ConcludePhase(InternalMessage):
 class GameUpdate(GameToPlayerMessage):
     game_state: GameState
 
+
 @dataclass(frozen=True)
 class PlayerNotInTurn(GameToPlayerMessage):
     pass
 
+
 @dataclass(frozen=True)
 class Ack(GameToPlayerMessage):
     message: str = "👍"
+
 
 @dataclass(frozen=True)
 class Ack(GameToPlayerMessage):
@@ -103,12 +106,7 @@ class UpdateBatchBidsRequest(PlayerToGameMessage):
     bids: MappingProxyType[AssetId, float]
 
     def make_response(self, success: bool, message: str) -> UpdateBatchBidResponse:
-        return UpdateBatchBidResponse(
-            game_id=self.game_id,
-            player_id=self.player_id,
-            success=success,
-            message=message
-        )
+        return UpdateBatchBidResponse(game_id=self.game_id, player_id=self.player_id, success=success, message=message)
 
 
 @dataclass(frozen=True)
@@ -129,6 +127,7 @@ class BuyRequest[T_Id](PlayerToGameMessage):
             purchase_id=self.purchase_id,
             message=message,
         )
+
 
 @dataclass(frozen=True)
 class ActivationUpdateRequest(PlayerToGameMessage):

--- a/back_end/src/models/message.py
+++ b/back_end/src/models/message.py
@@ -92,21 +92,8 @@ class Ack(GameToPlayerMessage):
 
 
 @dataclass(frozen=True)
-class Ack(GameToPlayerMessage):
-    message: str = "👍"
-
-
-@dataclass(frozen=True)
-class UpdateBatchBidResponse(GameToPlayerMessage):
-    success: bool
-
-
-@dataclass(frozen=True)
 class UpdateBatchBidsRequest(PlayerToGameMessage):
     bids: MappingProxyType[AssetId, float]
-
-    def make_response(self, success: bool, message: str) -> UpdateBatchBidResponse:
-        return UpdateBatchBidResponse(game_id=self.game_id, player_id=self.player_id, success=success, message=message)
 
 
 @dataclass(frozen=True)

--- a/back_end/src/models/pending_state.py
+++ b/back_end/src/models/pending_state.py
@@ -6,6 +6,7 @@ from src.models.ids import AssetId, TransmissionId
 
 @dataclass(frozen=True)
 class PendingState:
+    # A record of actions that have been taken but are not yet public
     line_activation: MappingProxyType[TransmissionId, bool] = field(default_factory=lambda: MappingProxyType({}))
     asset_activation: MappingProxyType[AssetId, bool] = field(default_factory=lambda: MappingProxyType({}))
     bids: MappingProxyType[AssetId, float] = field(default_factory=lambda: MappingProxyType({}))

--- a/back_end/src/models/pending_state.py
+++ b/back_end/src/models/pending_state.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import ClassVar
 
 from src.models.ids import AssetId, TransmissionId
 

--- a/back_end/src/models/pending_state.py
+++ b/back_end/src/models/pending_state.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from types import MappingProxyType
+from typing import ClassVar
 
 from src.models.ids import AssetId, TransmissionId
 
@@ -8,24 +9,32 @@ from src.models.ids import AssetId, TransmissionId
 class PendingState:
     line_activation: MappingProxyType[TransmissionId, bool] = field(default_factory=lambda: MappingProxyType({}))
     asset_activation: MappingProxyType[AssetId, bool] = field(default_factory=lambda: MappingProxyType({}))
+    bids: MappingProxyType[AssetId, float] = field(default_factory=lambda: MappingProxyType({}))
+
+    @classmethod
+    def get_field_names_and_types(cls) -> dict[str, type]:
+        return {"line_activation": TransmissionId, "asset_activation": AssetId, "bids": AssetId}
 
     def update(self, ps: "PendingState") -> "PendingState":
         return PendingState(
             line_activation=self.join_dicts(self.line_activation, ps.line_activation),
-            asset_activation=self.join_dicts(self.asset_activation, ps.asset_activation)
+            asset_activation=self.join_dicts(self.asset_activation, ps.asset_activation),
+            bids=self.join_dicts(self.bids, ps.bids),
         )
 
     def to_simple_dict(self) -> dict[str, dict]:
         return {
             "line_activation": {k.as_int(): v for k, v in self.line_activation.items()},
-            "asset_activation": {k.as_int(): v for k, v in self.asset_activation.items()}
+            "asset_activation": {k.as_int(): v for k, v in self.asset_activation.items()},
+            "bids": {k.as_int(): v for k, v in self.bids.items()},
         }
 
     @classmethod
-    def from_simple_dict(self, x: dict) -> "PendingState":
+    def from_simple_dict(cls, x: dict) -> "PendingState":
         return PendingState(
             line_activation=MappingProxyType({TransmissionId(k): v for k, v in x["line_activation"].items()}),
-            asset_activation=MappingProxyType({AssetId(k): v for k, v in x["asset_activation"].items()})
+            asset_activation=MappingProxyType({AssetId(k): v for k, v in x["asset_activation"].items()}),
+            bids=MappingProxyType({AssetId(k): v for k, v in x["bids"].items()}),
         )
 
     @staticmethod

--- a/back_end/src/models/server_models.py
+++ b/back_end/src/models/server_models.py
@@ -12,9 +12,7 @@ from types import MappingProxyType
 from pydantic import BaseModel
 
 from src.models.ids import AssetId, GameId, PlayerId, TransmissionId
-from src.models.message import ActivationUpdateRequest, BuyRequest, EndTurn, GameToPlayerMessage, PlayerToGameMessage, UpdateBatchBidsRequest, UpdateBidRequest
-
-# Serialization handled by message objects directly
+from src.models.message import ActivationUpdateRequest, BuyRequest, EndTurn, GameToPlayerMessage, PlayerToGameMessage, UpdateBatchBidsRequest
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -57,7 +55,6 @@ class WebsocketMessage(BaseModel):
     def to_py_message(self) -> PlayerToGameMessage:
         mapping: dict[type[PlayerToGameMessage], Callable[[], PlayerToGameMessage]] = {
             UpdateBatchBidsRequest: self._to_batch_bid_request,
-            UpdateBidRequest: self._to_bid_request,
             BuyRequest: self._to_buy_request,
             ActivationUpdateRequest: self._to_activation_update_request,
             EndTurn: self._to_end_turn,
@@ -70,9 +67,6 @@ class WebsocketMessage(BaseModel):
 
     def _to_batch_bid_request(self) -> UpdateBatchBidsRequest:
         return UpdateBatchBidsRequest(game_id=self.game_id_obj, player_id=self.player_id_obj, bids=MappingProxyType({AssetId(int(k)): v for k, v in self.data["bids"].items()}))
-
-    def _to_bid_request(self) -> UpdateBidRequest:
-        return UpdateBidRequest(game_id=self.game_id_obj, player_id=self.player_id_obj, asset_id=AssetId(self.data["asset_id"]), bid_price=self.data["bid_price"])
 
     def _to_buy_request(self) -> BuyRequest[AssetId | TransmissionId]:
         id_type = {"asset": AssetId, "transmission": TransmissionId}[self.data["purchase_type"]]

--- a/back_end/src/new_game/__init__.py
+++ b/back_end/src/new_game/__init__.py
@@ -1,6 +1,7 @@
 """
 new_game
 """
+
 from src.new_game.new_game import GameInitializer
 
 __all__ = ["GameInitializer"]

--- a/back_end/src/new_game/generators/generator_maker.py
+++ b/back_end/src/new_game/generators/generator_maker.py
@@ -12,14 +12,7 @@ class GeneratorMaker:
     path = Path(os.path.dirname(__file__))
 
     @classmethod
-    def make_one(
-            cls,
-            asset_id: AssetId,
-            bus_id: BusId,
-            current_round: Round,
-            technology_name: str | None = None,
-            player_id: PlayerId = PlayerId.get_npc()
-    ) -> AssetInfo:
+    def make_one(cls, asset_id: AssetId, bus_id: BusId, current_round: Round, technology_name: str | None = None, player_id: PlayerId = PlayerId.get_npc()) -> AssetInfo:
         """Create a generator with properties based on the current round."""
         if technology_name is None:
             technology_name = random_choice(cls.get_available_technologies())

--- a/back_end/src/new_game/loads/load_maker.py
+++ b/back_end/src/new_game/loads/load_maker.py
@@ -12,15 +12,7 @@ class LoadMaker:
     path = Path(os.path.dirname(__file__))
 
     @classmethod
-    def make_one(
-            cls,
-            asset_id: AssetId,
-            bus_id: BusId,
-            current_round: Round,
-            technology_name: str | None = None,
-            player_id: PlayerId = PlayerId.get_npc(),
-            except_freezer: bool = True
-    ) -> AssetInfo:
+    def make_one(cls, asset_id: AssetId, bus_id: BusId, current_round: Round, technology_name: str | None = None, player_id: PlayerId = PlayerId.get_npc(), except_freezer: bool = True) -> AssetInfo:
         """Create a load with properties based on the current round."""
         if technology_name is None:
             available_techs = cls.get_available_technologies()

--- a/back_end/src/new_game/price_asset.py
+++ b/back_end/src/new_game/price_asset.py
@@ -5,7 +5,6 @@ from randcraft import RandomVariable, make_uniform
 
 
 def price_asset(kind: Literal["load", "gen"], marginal_price: float, expected_power: float, foc: float, lifespan: int, market_prices: RandomVariable | None = None) -> int:
-
     assert kind in ["load", "gen"]
     if market_prices is None:
         market_prices = make_uniform(low=0, high=800)
@@ -13,12 +12,10 @@ def price_asset(kind: Literal["load", "gen"], marginal_price: float, expected_po
 
     inframarginal_rent = marginal_price * np.ones_like(sample_prices) - sample_prices
     if kind == "load":
-        inframarginal_rent = inframarginal_rent *-1
+        inframarginal_rent = inframarginal_rent * -1
 
     profit = (inframarginal_rent * expected_power - foc).clip(min=0).mean()
 
     rng = np.random.default_rng()
     price = profit * lifespan * rng.uniform(low=0.4, high=1.0)
     return round(price)
-
-

--- a/back_end/tests/test_engine/test_engine.py
+++ b/back_end/tests/test_engine/test_engine.py
@@ -46,9 +46,7 @@ class TestEngine(BaseTest):
         game_state = game_state.update(new_player_repo, construction_phase)
 
         player_msg = BuyRequest(game_state.game_id, player_not_in_turn, game_state.assets.asset_ids[-1])
-        result_game_state, failed_message = Engine.handle_message(
-            game_state=game_state, msg=player_msg
-        )
+        result_game_state, failed_message = Engine.handle_message(game_state=game_state, msg=player_msg)
         self.assertIsInstance(failed_message[0], PlayerNotInTurn)
 
     def test_buy_asset_message(self) -> None:
@@ -137,19 +135,8 @@ class TestEngine(BaseTest):
         game_state = GameStateMaker().add_player_repo(player_repo).add_bus_repo(bus_repo).add_transmission_repo(transmission_repo).add_phase(Phase.SNEAKY_TRICKS).make()
         game_state = give_turn_to_player(game_state, player.id)
 
-
-        deactivate_request = ActivationUpdateRequest(
-            game_id=game_state.game_id,
-            player_id=player.id,
-            line_activation=MappingProxyType({my_line.id: False}),
-            asset_activation=MappingProxyType({})
-        )
-        activate_request = ActivationUpdateRequest(
-            game_id=game_state.game_id,
-            player_id=player.id,
-            line_activation=MappingProxyType({my_line.id: True}),
-            asset_activation=MappingProxyType({})
-        )
+        deactivate_request = ActivationUpdateRequest(game_id=game_state.game_id, player_id=player.id, line_activation=MappingProxyType({my_line.id: False}), asset_activation=MappingProxyType({}))
+        activate_request = ActivationUpdateRequest(game_id=game_state.game_id, player_id=player.id, line_activation=MappingProxyType({my_line.id: True}), asset_activation=MappingProxyType({}))
         game_state, responses = Engine.handle_message(game_state=game_state, msg=deactivate_request)
 
         self.assertEqual(len(responses), 1)
@@ -168,7 +155,6 @@ class TestEngine(BaseTest):
         self.assertEqual(game_state.transmission[my_line.id].is_active, False)
         game_state = game_state.commit_pending_state()
         self.assertEqual(game_state.transmission[my_line.id].is_active, True)
-
 
     def test_operate_asset_messages(self) -> None:
         player_repo = PlayerRepoMaker.make_quick()
@@ -182,18 +168,8 @@ class TestEngine(BaseTest):
         game_state = GameStateMaker().add_player_repo(player_repo).add_bus_repo(bus_repo).add_asset_repo(asset_repo).add_phase(Phase.SNEAKY_TRICKS).make()
         game_state = game_state.start_all_turns()
 
-        deactivate_request = ActivationUpdateRequest(
-            game_id=GameId(0),
-            player_id=player.id,
-            line_activation=MappingProxyType({}),
-            asset_activation=MappingProxyType({my_generator.id: False})
-        )
-        activate_request = ActivationUpdateRequest(
-            game_id=GameId(0),
-            player_id=player.id,
-            line_activation=MappingProxyType({}),
-            asset_activation=MappingProxyType({my_generator.id: True})
-        )
+        deactivate_request = ActivationUpdateRequest(game_id=GameId(0), player_id=player.id, line_activation=MappingProxyType({}), asset_activation=MappingProxyType({my_generator.id: False}))
+        activate_request = ActivationUpdateRequest(game_id=GameId(0), player_id=player.id, line_activation=MappingProxyType({}), asset_activation=MappingProxyType({my_generator.id: True}))
         game_state, responses = Engine.handle_message(game_state=game_state, msg=deactivate_request)
 
         self.assertEqual(len(responses), 1)
@@ -212,8 +188,6 @@ class TestEngine(BaseTest):
         self.assertEqual(game_state.assets[my_generator.id].is_active, False)
         game_state = game_state.commit_pending_state()
         self.assertEqual(game_state.assets[my_generator.id].is_active, True)
-
-
 
     def test_post_clearing_book_keeping(self):
         game_maker = GameStateMaker()

--- a/back_end/tests/test_engine/test_generator_maker.py
+++ b/back_end/tests/test_engine/test_generator_maker.py
@@ -5,20 +5,13 @@ from tests.base_test import BaseTest
 
 
 class TestGeneratorMaker(BaseTest):
-
     def test_make_generator(self):
-        generator = GeneratorMaker.make_one(
-            technology_name='wind',
-            asset_id=AssetId(1),
-            bus_id=BusId(1),
-            current_round=Round(0),
-            player_id=PlayerId.get_npc()
-        )
+        generator = GeneratorMaker.make_one(technology_name="wind", asset_id=AssetId(1), bus_id=BusId(1), current_round=Round(0), player_id=PlayerId.get_npc())
 
         self.assertIsInstance(generator, AssetInfo)
 
     def test_available_technologies(self):
         technologies = GeneratorMaker.get_available_technologies()
 
-        for tech in ['wind', 'nuclear', 'ccgt']:
+        for tech in ["wind", "nuclear", "ccgt"]:
             self.assertIn(tech, technologies)

--- a/back_end/tests/test_engine/test_grid_expansion.py
+++ b/back_end/tests/test_engine/test_grid_expansion.py
@@ -7,12 +7,9 @@ from tests.utils.game_state_maker import GameStateMaker
 
 
 class TestGridExpansion(BaseTest):
-
     @staticmethod
     def _create_game_state_without_assets() -> GameState:
-        settings = GameSettings(
-            probability_of_new_asset=1.0
-        )
+        settings = GameSettings(probability_of_new_asset=1.0)
         gs = GameStateMaker().make().update(settings)
         return gs
 

--- a/back_end/tests/test_engine/test_load_maker.py
+++ b/back_end/tests/test_engine/test_load_maker.py
@@ -5,20 +5,13 @@ from tests.base_test import BaseTest
 
 
 class TestLoadMaker(BaseTest):
-
     def test_make_load(self):
-        load = LoadMaker.make_one(
-            technology_name='residential',
-            asset_id=AssetId(1),
-            bus_id=BusId(1),
-            current_round=Round(0),
-            player_id=PlayerId.get_npc()
-        )
+        load = LoadMaker.make_one(technology_name="residential", asset_id=AssetId(1), bus_id=BusId(1), current_round=Round(0), player_id=PlayerId.get_npc())
 
         self.assertIsInstance(load, AssetInfo)
 
     def test_available_technologies(self):
         technologies = LoadMaker.get_available_technologies()
 
-        for tech in ['residential', 'industrial']:
+        for tech in ["residential", "industrial"]:
             self.assertIn(tech, technologies)

--- a/back_end/tests/test_engine/test_market_coupling.py
+++ b/back_end/tests/test_engine/test_market_coupling.py
@@ -178,9 +178,7 @@ class TestMarketCoupling(BaseTest):
         with self.assertLogs("src.engine.market_coupling") as cm:
             MarketCouplingCalculator.run(game_state_no_assets)
 
-        self.assertIn(
-            "No active assets, skipping market coupling", cm.output[0]
-        )
+        self.assertIn("No active assets, skipping market coupling", cm.output[0])
 
     def test_coupling_under_market_split(self) -> None:
         gs = self.create_game_state()
@@ -191,7 +189,5 @@ class TestMarketCoupling(BaseTest):
         with self.assertLogs("src.engine.market_coupling") as cm:
             result = MarketCouplingCalculator.run(game_state_no_transmission)
 
-        self.assertIn(
-            "Optimization successfully ended with status: optimal", cm.output[0]
-        )
+        self.assertIn("Optimization successfully ended with status: optimal", cm.output[0])
         assert result.transmission_flows.empty, "Expected no transmission flows when there are no transmission lines."

--- a/back_end/tests/test_models/test_transmission.py
+++ b/back_end/tests/test_models/test_transmission.py
@@ -6,32 +6,14 @@ from tests.utils.repo_maker import TransmissionInfo, TransmissionRepo
 
 class TestTransmission(BaseTest):
     def test_get_bus_pairs(self) -> None:
-        repo = TransmissionRepo(dcs=[
-            TransmissionInfo(
-                id=TransmissionId(0),
-                owner_player=PlayerId(1),
-                bus1=BusId(0),
-                bus2=BusId(1),
-                reactance=0.1
-            ),
-            TransmissionInfo(
-                id=TransmissionId(1),
-                owner_player=PlayerId(1),
-                bus1=BusId(0),
-                bus2=BusId(1),
-                reactance=0.1
-            ),
-            TransmissionInfo(
-                id=TransmissionId(2),
-                owner_player=PlayerId(1),
-                bus1=BusId(1),
-                bus2=BusId(2),
-                reactance=0.1
-            )
-
-        ])
+        repo = TransmissionRepo(
+            dcs=[
+                TransmissionInfo(id=TransmissionId(0), owner_player=PlayerId(1), bus1=BusId(0), bus2=BusId(1), reactance=0.1),
+                TransmissionInfo(id=TransmissionId(1), owner_player=PlayerId(1), bus1=BusId(0), bus2=BusId(1), reactance=0.1),
+                TransmissionInfo(id=TransmissionId(2), owner_player=PlayerId(1), bus1=BusId(1), bus2=BusId(2), reactance=0.1),
+            ]
+        )
         bus_pairs = repo.get_all_bus_pairs()
         self.assertEqual(len(bus_pairs), 3)
         self.assertEqual(len(set(bus_pairs)), 2)
         self.assertEqual(bus_pairs[0], (BusId(0), BusId(1)))
-

--- a/back_end/tests/utils/comparisons.py
+++ b/back_end/tests/utils/comparisons.py
@@ -59,7 +59,7 @@ class GameStateComparator:
 
     @classmethod
     def pending_states_are_equal(cls, ps1: PendingState, ps2: PendingState) -> bool:
-        dict_pairs = [(ps1.asset_activation, ps2.asset_activation), (ps1.line_activation, ps2.line_activation)]
+        dict_pairs = [(ps1.asset_activation, ps2.asset_activation), (ps1.line_activation, ps2.line_activation), (ps1.bids, ps2.bids)]
         for dp in dict_pairs:
             d1, d2 = dp
             if not cls.dicts_equal(d1, d2):

--- a/back_end/tests/utils/comparisons.py
+++ b/back_end/tests/utils/comparisons.py
@@ -34,7 +34,7 @@ class GameStateComparator:
             "assets": lambda: game_state1.assets == game_state2.assets,
             "transmission": lambda: game_state1.transmission == game_state2.transmission,
             "market_coupling_result": lambda: cls.market_coupling_result_is_equal(game_state1.market_coupling_result, game_state2.market_coupling_result),
-            "pending_state": lambda: cls.pending_states_are_equal(game_state1.pending_state, game_state2.pending_state)
+            "pending_state": lambda: cls.pending_states_are_equal(game_state1.pending_state, game_state2.pending_state),
         }
 
     @staticmethod
@@ -74,7 +74,6 @@ class GameStateComparator:
             if v != d2[k]:
                 return False
         return True
-
 
 
 def game_states_are_equal(game_state1: GameState, game_state2: GameState) -> bool:

--- a/back_end/tests/utils/game_state_maker.py
+++ b/back_end/tests/utils/game_state_maker.py
@@ -215,11 +215,7 @@ class GameStateMaker:
             else:
                 line_id = self.transmission_repo.transmission_ids[0]
                 asset_id = self.asset_repo.asset_ids[0]
-                self.pending_state = PendingState(
-                    line_activation=MappingProxyType({line_id: True}),
-                    asset_activation=MappingProxyType({asset_id: False})
-                )
-
+                self.pending_state = PendingState(line_activation=MappingProxyType({line_id: True}), asset_activation=MappingProxyType({asset_id: False}))
 
         return GameState(
             game_id=self.game_id,
@@ -230,5 +226,5 @@ class GameStateMaker:
             assets=self.asset_repo,
             transmission=self.transmission_repo,
             market_coupling_result=self.market_coupling_result,
-            pending_state=self.pending_state
+            pending_state=self.pending_state,
         )

--- a/back_end/tests/utils/game_state_maker.py
+++ b/back_end/tests/utils/game_state_maker.py
@@ -215,7 +215,7 @@ class GameStateMaker:
             else:
                 line_id = self.transmission_repo.transmission_ids[0]
                 asset_id = self.asset_repo.asset_ids[0]
-                self.pending_state = PendingState(line_activation=MappingProxyType({line_id: True}), asset_activation=MappingProxyType({asset_id: False}))
+                self.pending_state = PendingState(line_activation=MappingProxyType({line_id: True}), asset_activation=MappingProxyType({asset_id: False}), bids=MappingProxyType({asset_id: 20.0}))
 
         return GameState(
             game_id=self.game_id,

--- a/front_end/src/app/page.tsx
+++ b/front_end/src/app/page.tsx
@@ -92,15 +92,11 @@ export default function Home() {
 
   // Calculate current player name and trigram from gameState
   const currentPlayerName = React.useMemo(() => {
-    return currentPlayerObj
-      ? currentPlayerObj.name
-      : `Player ${currentPlayer}`;
+    return currentPlayerObj ? currentPlayerObj.name : `Player ${currentPlayer}`;
   }, [currentPlayerObj, currentPlayer]);
 
   const currentPlayerTrigram = React.useMemo(() => {
-    return currentPlayerObj
-      ? currentPlayerObj.trigram
-      : `P${currentPlayer}`;
+    return currentPlayerObj ? currentPlayerObj.trigram : `P${currentPlayer}`;
   }, [currentPlayerObj, currentPlayer]);
 
   const { createGame, loading: creatingGame } = useCreateGame();
@@ -147,12 +143,7 @@ export default function Home() {
         wsClient.setCurrentPlayerId(DEFAULT_PLAYER);
       }
     }
-  }, [
-    wsClient,
-    showSetup,
-    gameMode,
-    currentPlayer,
-  ]);
+  }, [wsClient, showSetup, gameMode, currentPlayer]);
 
   const handlePurchaseAsset = (assetId: number) => {
     if (!wsClient || !wsClient.isConnected()) {
@@ -244,7 +235,7 @@ export default function Home() {
         });
       }
     }
-    
+
     // Submit pending bids if in bidding phase
     if (gameState?.phase === 2) {
       if (Object.keys(pendingBids).length > 0) {
@@ -252,7 +243,7 @@ export default function Home() {
         wsClient.submitBatchBids(pendingBids);
       }
     }
-    
+
     // Clear pending activations and bids at end of turn
     setPendingActivations({ lines: {}, assets: {} });
     setPendingBids({});

--- a/front_end/src/app/page.tsx
+++ b/front_end/src/app/page.tsx
@@ -1,17 +1,17 @@
 "use client";
 
+import BiddingTable from "@/components/Game/BiddingTable";
 import GridVisualization from "@/components/Game/GridVisualization";
 import GameControls from "@/components/UI/GameControls";
 import GameStatus from "@/components/UI/GameStatus";
 import PlayerTable from "@/components/UI/PlayerTable";
 import { useCreateGame, useGamesList } from "@/lib/gameAPI";
-import BiddingTable from "@/components/Game/BiddingTable";
 import { useGameWebSocket, type WebSocketMessage } from "@/lib/gameWebSocket";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 
 export default function Home() {
   const [gameId, setGameId] = useState<number>(-1);
-  const [currentPlayer] = useState(1); // For demo purposes, assume player_1 is active
+  const DEFAULT_PLAYER = 1; // For demo purposes, assume player_1 is active
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedGameId, setSelectedGameId] = useState<number>(-1);
@@ -62,11 +62,11 @@ export default function Home() {
     connectionState,
     gameState,
     isConnected,
-  } = useGameWebSocket(gameId, currentPlayer, callbacks);
+  } = useGameWebSocket(gameId, DEFAULT_PLAYER, callbacks);
 
   // Calculate current player from gameState (who is having their turn)
-  const currentPlayerFromGameState = React.useMemo(() => {
-    if (!gameState) return currentPlayer;
+  const currentPlayer = React.useMemo(() => {
+    if (!gameState) return DEFAULT_PLAYER;
 
     // Handle both array format (sample data) and repo format (backend)
     const playersArray = Array.isArray(gameState.players)
@@ -75,8 +75,8 @@ export default function Home() {
 
     // Find the player who is currently having their turn
     const activePlayer = playersArray.find((p: any) => p.is_having_turn);
-    return activePlayer ? activePlayer.id : currentPlayer;
-  }, [gameState, currentPlayer]);
+    return activePlayer ? activePlayer.id : DEFAULT_PLAYER;
+  }, [gameState]);
 
   // Calculate current player object and name from gameState
   const currentPlayerObj = React.useMemo(() => {
@@ -87,21 +87,21 @@ export default function Home() {
       ? gameState.players
       : gameState.players?.data || [];
 
-    return playersArray.find((p: any) => p.id === currentPlayerFromGameState);
-  }, [gameState, currentPlayerFromGameState]);
+    return playersArray.find((p: any) => p.id === currentPlayer);
+  }, [gameState, currentPlayer]);
 
   // Calculate current player name and trigram from gameState
   const currentPlayerName = React.useMemo(() => {
     return currentPlayerObj
       ? currentPlayerObj.name
-      : `Player ${currentPlayerFromGameState}`;
-  }, [currentPlayerObj, currentPlayerFromGameState]);
+      : `Player ${currentPlayer}`;
+  }, [currentPlayerObj, currentPlayer]);
 
   const currentPlayerTrigram = React.useMemo(() => {
     return currentPlayerObj
       ? currentPlayerObj.trigram
-      : `P${currentPlayerFromGameState}`;
-  }, [currentPlayerObj, currentPlayerFromGameState]);
+      : `P${currentPlayer}`;
+  }, [currentPlayerObj, currentPlayer]);
 
   const { createGame, loading: creatingGame } = useCreateGame();
   const { games, loading: gamesLoading, error: gamesError } = useGamesList();
@@ -142,16 +142,15 @@ export default function Home() {
   React.useEffect(() => {
     if (wsClient && !showSetup) {
       if (gameMode === "local") {
-        wsClient.setCurrentPlayerId(currentPlayerFromGameState);
-      } else {
         wsClient.setCurrentPlayerId(currentPlayer);
+      } else {
+        wsClient.setCurrentPlayerId(DEFAULT_PLAYER);
       }
     }
   }, [
     wsClient,
     showSetup,
     gameMode,
-    currentPlayerFromGameState,
     currentPlayer,
   ]);
 
@@ -175,17 +174,20 @@ export default function Home() {
     wsClient.buyTransmissionLine(lineId.toString());
   };
 
-  // State for activation changes during sneaky tricks phase
-  // Reset when current player or phase changes
   const [pendingActivations, setPendingActivations] = useState<{
     lines: Record<number, boolean>;
     assets: Record<number, boolean>;
   }>({ lines: {}, assets: {} });
+  const [pendingBids, setPendingBids] = useState<Record<number, number>>({});
+
+  // State to track insufficient funds status from BiddingTable
+  const [hasInsufficientFunds, setHasInsufficientFunds] = useState(false);
 
   // Reset pending activations when current player or phase changes
   useEffect(() => {
     setPendingActivations({ lines: {}, assets: {} });
-  }, [gameState?.phase, currentPlayerFromGameState]);
+    setPendingBids({});
+  }, [gameState?.phase, currentPlayer]);
 
   const handleActivateLine = (lineId: number) => {
     // Store activation in pending state
@@ -223,34 +225,18 @@ export default function Home() {
     console.log(`Deactivating asset ${assetId} - stored locally`);
   };
 
-  const handleSubmitAllBids = () => {
-    if (!wsClient || !wsClient.isConnected()) {
-      setError("Not connected to server");
-      return;
-    }
-
-    if (Object.keys(pendingBids).length === 0) {
-      setError("No pending bids to submit");
-      return;
-    }
-
-    console.log("Submitting all bids:", pendingBids);
-    wsClient.submitBatchBids(pendingBids);
-    setPendingBids({}); // Clear pending bids after submission
-  };
-
   const handleEndTurn = () => {
     if (!wsClient || !wsClient.isConnected()) {
       setError("Not connected to server");
       return;
     }
 
-    // Check if we're in sneaky tricks phase with pending activations
+    // Submit pending activations if in sneaky tricks phase
     if (gameState?.phase === 1) {
-      const hasUpdates =
+      const hasActivations =
         Object.keys(pendingActivations.lines).length > 0 ||
         Object.keys(pendingActivations.assets).length > 0;
-      if (hasUpdates) {
+      if (hasActivations) {
         console.log("Submitting activation updates:", pendingActivations);
         wsClient.activationUpdate({
           line_activation: pendingActivations.lines,
@@ -258,18 +244,22 @@ export default function Home() {
         });
       }
     }
-    // Clear pending activations at end of turn
+    
+    // Submit pending bids if in bidding phase
+    if (gameState?.phase === 2) {
+      if (Object.keys(pendingBids).length > 0) {
+        console.log("Submitting pending bids:", pendingBids);
+        wsClient.submitBatchBids(pendingBids);
+      }
+    }
+    
+    // Clear pending activations and bids at end of turn
     setPendingActivations({ lines: {}, assets: {} });
+    setPendingBids({});
 
     console.log("Ending turn");
     wsClient.endTurn();
   };
-
-  // State for batch bidding
-  const [pendingBids, setPendingBids] = useState<Record<number, number>>({});
-
-  // State to track insufficient funds status from BiddingTable
-  const [hasInsufficientFunds, setHasInsufficientFunds] = useState(false);
 
   const handleBidAsset = (assetId: number, newBidPrice: number) => {
     // Store bid locally instead of sending immediately
@@ -278,11 +268,6 @@ export default function Home() {
       [assetId]: newBidPrice,
     }));
     console.log("Stored bid for asset:", assetId, "to:", newBidPrice);
-  };
-
-  const handleBidChange = (assetId: number, newBidPrice: number) => {
-    // This is called from the bidding table when input changes
-    handleBidAsset(assetId, newBidPrice);
   };
 
   // Show setup screen if not yet started
@@ -549,7 +534,7 @@ export default function Home() {
                 onDeactivateLine={handleDeactivateLine}
                 onActivateAsset={handleActivateAsset}
                 onDeactivateAsset={handleDeactivateAsset}
-                currentPlayer={currentPlayerFromGameState}
+                currentPlayer={currentPlayer}
                 pendingActivations={pendingActivations}
               />
             </div>
@@ -566,8 +551,6 @@ export default function Home() {
               currentPlayerColor={currentPlayerObj?.color}
               isConnected={isConnected}
               onEndTurn={handleEndTurn}
-              onSubmitBids={handleSubmitAllBids}
-              hasPendingBids={Object.keys(pendingBids).length > 0}
               hasInsufficientFunds={hasInsufficientFunds}
             />
 
@@ -575,10 +558,10 @@ export default function Home() {
             {gameState.phase === 2 && (
               <BiddingTable
                 assets={gameState.assets.data}
-                currentPlayer={currentPlayerFromGameState}
+                currentPlayer={currentPlayer}
                 playerMoney={currentPlayerObj?.money || 0}
                 pendingBids={pendingBids}
-                onBidChange={handleBidChange}
+                onBidChange={handleBidAsset}
                 onInsufficientFundsChange={setHasInsufficientFunds}
               />
             )}

--- a/front_end/src/components/UI/GameControls.tsx
+++ b/front_end/src/components/UI/GameControls.tsx
@@ -11,8 +11,6 @@ interface GameControlsProps {
   currentPlayerColor: string;
   isConnected: boolean;
   onEndTurn: () => void;
-  onSubmitBids?: () => void;
-  hasPendingBids?: boolean;
   hasInsufficientFunds?: boolean;
 }
 
@@ -24,8 +22,6 @@ const GameControls: React.FC<GameControlsProps> = ({
   currentPlayerColor,
   isConnected,
   onEndTurn,
-  onSubmitBids,
-  hasPendingBids = false,
   hasInsufficientFunds = false,
 }) => {
   return (
@@ -47,20 +43,10 @@ const GameControls: React.FC<GameControlsProps> = ({
         </div>
       )}
       <div className="space-y-4">
-        {gameState.phase === 2 && onSubmitBids && (
-          <button
-            onClick={onSubmitBids}
-            disabled={!isConnected || !hasPendingBids || hasInsufficientFunds}
-            className={`w-full px-4 py-2 text-white rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 transition-colors $
-              ${hasInsufficientFunds ? "bg-red-600 hover:bg-red-700 focus:ring-red-500" : "bg-green-600 hover:bg-green-700 focus:ring-green-500"}
-              ${!isConnected || !hasPendingBids || hasInsufficientFunds ? "disabled:bg-gray-400 disabled:cursor-not-allowed" : ""}`}
-          >
-            {hasInsufficientFunds ? "Insufficient Funds" : "Submit All Bids"}
-          </button>
-        )}
+
         <button
           onClick={onEndTurn}
-          disabled={!isConnected || hasPendingBids || hasInsufficientFunds}
+          disabled={!isConnected || hasInsufficientFunds}
           className="w-full px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
         >
           End Turn

--- a/front_end/src/components/UI/GameControls.tsx
+++ b/front_end/src/components/UI/GameControls.tsx
@@ -43,7 +43,6 @@ const GameControls: React.FC<GameControlsProps> = ({
         </div>
       )}
       <div className="space-y-4">
-
         <button
           onClick={onEndTurn}
           disabled={!isConnected || hasInsufficientFunds}


### PR DESCRIPTION
Added pending action pattern to bids.

I think there is some formatting differences for some reason so lots of files are changed, I commented on the interesting ones

There is a concept of PendingActions, these are actions that have been decided upon, but are not yet made public. Asset/line activation and bids are in this category.

This is how it works (using bids as an example but the same applies to activations):
- The player can see what they are doing with bids during their turn
- When they end their turn, their pending actions get sent to the back end and cleared from the front end
- When the game state gets sent to the front end, pending actions are not included
- Therefore the next player cannot find out what the previous player bid even by debugging the browser
- When all players are finished bidding, the pending actions get committed to the main game state