### PR TITLE
Hf 73 implement transmission maker

### DIFF
--- a/back_end/src/engine/market_coupling.py
+++ b/back_end/src/engine/market_coupling.py
@@ -46,17 +46,17 @@ class MarketCouplingCalculator:
         network.add(class_name="Carrier", name="AC")
         for bus in game_state.buses:
             network.add(class_name="Bus", name=cls.get_pypsa_name(bus.id), carrier="AC")
-        for line in game_state.transmission:
-            if not line.is_active:
+        for transmission in game_state.transmission:
+            if not transmission.is_active:
                 continue
             network.add(
-                class_name="Line",
-                name=cls.get_pypsa_name(line.id),
-                bus0=cls.get_pypsa_name(line.bus1),
-                bus1=cls.get_pypsa_name(line.bus2),
-                x=line.reactance,
+                class_name=transmission.line_or_link,
+                name=cls.get_pypsa_name(transmission.id),
+                bus0=cls.get_pypsa_name(transmission.bus1),
+                bus1=cls.get_pypsa_name(transmission.bus2),
+                x=transmission.reactance,
                 # r=0.01 * line.reactance,  # Assuming a small resistance for numerical stability
-                s_nom=line.capacity,
+                s_nom=transmission.capacity,
                 carrier="AC",
             )
         for generator in game_state.assets.only_generators:

--- a/back_end/src/engine/market_coupling.py
+++ b/back_end/src/engine/market_coupling.py
@@ -44,21 +44,34 @@ class MarketCouplingCalculator:
         network.set_snapshots(pd.Index([0], name="time"))  # type: ignore
 
         network.add(class_name="Carrier", name="AC")
+
         for bus in game_state.buses:
             network.add(class_name="Bus", name=cls.get_pypsa_name(bus.id), carrier="AC")
+
         for transmission in game_state.transmission:
             if not transmission.is_active:
                 continue
+
+            if transmission.line_or_link=="Line":
+                other_parameters = {
+                    "x": transmission.reactance,
+                    "s_nom": transmission.capacity,
+                }
+            elif transmission.line_or_link=="Link":
+                other_parameters = {
+                    "p_nom": transmission.capacity,
+                }
+            else:
+                other_parameters = {}
+
             network.add(
                 class_name=transmission.line_or_link,
                 name=cls.get_pypsa_name(transmission.id),
                 bus0=cls.get_pypsa_name(transmission.bus1),
                 bus1=cls.get_pypsa_name(transmission.bus2),
-                x=transmission.reactance,
-                # r=0.01 * line.reactance,  # Assuming a small resistance for numerical stability
-                s_nom=transmission.capacity,
-                carrier="AC",
+                **other_parameters
             )
+
         for generator in game_state.assets.only_generators:
             if not generator.is_active:
                 continue
@@ -70,6 +83,7 @@ class MarketCouplingCalculator:
                 p_nom=generator.sample_power(),
                 carrier="AC",
             )
+
         for load in game_state.assets.only_loads:
             if not load.is_active:
                 continue
@@ -112,7 +126,10 @@ class MarketCouplingCalculator:
 
     @classmethod
     def get_transmission_flows(cls, network: pypsa.Network, transmission: TransmissionRepo) -> pd.DataFrame:
-        df = cls._tidy_df(df=network.lines_t.p0, column_name="Line")
+        df = cls._tidy_df(
+            df=pd.concat([network.lines_t.p0, network.links_t.p0], axis=1),
+            column_name="Line"
+        )
         # Add zero flows to open lines
         open_ids = transmission.only_open.transmission_ids
         df.loc[:, open_ids] = 0.0

--- a/back_end/src/engine/market_coupling.py
+++ b/back_end/src/engine/market_coupling.py
@@ -69,7 +69,7 @@ class MarketCouplingCalculator:
                 name=cls.get_pypsa_name(transmission.id),
                 bus0=cls.get_pypsa_name(transmission.bus1),
                 bus1=cls.get_pypsa_name(transmission.bus2),
-                **other_parameters
+                **other_parameters # type: ignore
             )
 
         for generator in game_state.assets.only_generators:

--- a/back_end/src/models/transmission.py
+++ b/back_end/src/models/transmission.py
@@ -23,6 +23,7 @@ class TransmissionInfo(LightDc):
     minimum_acquisition_price: float = 0.0  # 0 = Not for sale
     is_active: bool = True
     birthday: int = 1  # Round when the asset was created
+    line_or_link: str = "Line"
 
     @property
     def is_open(self) -> bool:
@@ -35,6 +36,7 @@ class TransmissionInfo(LightDc):
     def __post_init__(self) -> None:
         assert self.bus2 > self.bus1, f"bus2 must be greater than bus1. Got {self.bus2} and {self.bus1}"
         assert self.reactance > 0, f"Reactance must be positive. Got {self.reactance}"
+        assert self.line_or_link in ["Line", "Link"], f"line_or_link must be either 'Line' or 'Link'. Got {self.line_or_link}"
 
 
 class TransmissionRepo(LdcRepo[TransmissionInfo]):

--- a/back_end/src/new_game/new_game.py
+++ b/back_end/src/new_game/new_game.py
@@ -15,6 +15,7 @@ from src.models.player import Player, PlayerRepo
 from src.models.transmission import TransmissionId, TransmissionInfo, TransmissionRepo
 from src.new_game.generators.generator_maker import GeneratorMaker
 from src.new_game.loads.load_maker import LoadMaker
+from src.new_game.transmission.transmission_maker import TransmissionMaker
 from src.new_game.trigram_maker import make_trigrams
 from src.tools.random_choice import random_choice, random_choice_multi
 
@@ -285,13 +286,13 @@ class GameInitializer:
         gen_maker = GeneratorMaker()
         for _ in range(self.settings.n_init_assets):
             bus_id = socket_manager.get_bus_with_free_socket(use=True)
-            asset = gen_maker.make_one(asset_id=next(asset_ids), bus_id=bus_id, current_round=Round(0), player_id=PlayerId.get_npc())
+            asset = gen_maker.make_one(asset_id=next(asset_ids), bus_id=bus_id, current_round=Round(0))
             assets.append(asset)
 
         load_maker = LoadMaker()
         for _ in range(self.settings.n_init_non_freezer_loads):
             bus_id = socket_manager.get_bus_with_free_socket(use=True)
-            asset = load_maker.make_one(asset_id=next(asset_ids), bus_id=bus_id, current_round=Round(0), player_id=PlayerId.get_npc(), except_freezer=True)
+            asset = load_maker.make_one(asset_id=next(asset_ids), bus_id=bus_id, current_round=Round(0), except_freezer=True)
             assets.append(asset)
 
         return AssetRepo(assets)
@@ -311,7 +312,7 @@ class GameInitializer:
         # TODO This should be considered during topology construction rather than just checking it at the end
         socket_manager = BusSocketManager(starting_sockets={bus.id: bus.max_lines for bus in bus_repo})
 
-        rng = np.random.default_rng()
+        transmission_maker = TransmissionMaker()
 
         lines: list[TransmissionInfo] = []
         for bus1, bus2 in topology:
@@ -319,18 +320,7 @@ class GameInitializer:
             socket_manager.use_socket(bus1)
             socket_manager.use_socket(bus2)
 
-            line = TransmissionInfo(
-                id=next(t_id_iter),
-                owner_player=PlayerId.get_npc(),  # NPC owns all initial transmissions
-                bus1=bus1,
-                bus2=bus2,
-                reactance=rng.uniform(0.1, 1.0),  # Random reactance for each transmission
-                capacity=round(rng.uniform(10, 100)),
-                health=5,
-                fixed_operating_cost=1,
-                is_for_sale=True,
-                minimum_acquisition_price=round(rng.uniform(10, 100)),  # Random purchase cost for each transmission
-            )
+            line = transmission_maker.make_one(transmission_id=next(t_id_iter), bus1=bus1, bus2=bus2, current_round= Round(0))
             lines.append(line)
 
         return TransmissionRepo(lines)

--- a/back_end/src/new_game/transmission/tech_specs/ac.yaml
+++ b/back_end/src/new_game/transmission/tech_specs/ac.yaml
@@ -1,1 +1,34 @@
-placeholder
+line_or_link: "Line"
+
+reactance:
+  base: 2
+  change_per_round: -0.1
+  max: 2
+  min: 0.9
+  random_band_pu: 0.05
+
+capacity:
+  base: 20
+  change_per_round: 10
+  max: 400
+  min: 20
+  random_band_pu: 0.1
+
+capital_cost_per_mw:
+  base: 200
+  change_per_round: -5
+  max: 200
+  min: 30
+  random_band_pu: 0.1
+
+fixed_cost:
+  base: 0
+  change_per_round: 0
+  max: 0
+  min: 0
+
+lifespan:
+  base: 10
+  change_per_round: 0
+  max: 10
+  min: 10

--- a/back_end/src/new_game/transmission/tech_specs/dc.yaml
+++ b/back_end/src/new_game/transmission/tech_specs/dc.yaml
@@ -1,1 +1,35 @@
-placeholder
+line_or_link: "Link"
+
+# ToDo - all stats are the same as lines. Fix during game balancing
+reactance:
+  base: 2
+  change_per_round: -0.1
+  max: 2
+  min: 0.9
+  random_band_pu: 0.05
+
+capacity:
+  base: 20
+  change_per_round: 10
+  max: 400
+  min: 20
+  random_band_pu: 0.1
+
+capital_cost_per_mw:
+  base: 200
+  change_per_round: -5
+  max: 200
+  min: 30
+  random_band_pu: 0.1
+
+fixed_cost:
+  base: 0
+  change_per_round: 0
+  max: 0
+  min: 0
+
+lifespan:
+  base: 10
+  change_per_round: 0
+  max: 10
+  min: 10

--- a/back_end/src/new_game/transmission/tranmission_technology_specs.py
+++ b/back_end/src/new_game/transmission/tranmission_technology_specs.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import yaml
+
+from src.new_game.util.technology_specs import TechEvolutionIndicator
+
+
+@dataclass(frozen=True)
+class TransmissionTechnologySpecs:
+    technology_name: str
+    reactance: TechEvolutionIndicator
+    capacity: TechEvolutionIndicator
+    capital_cost_per_mw: TechEvolutionIndicator
+    fixed_cost: TechEvolutionIndicator
+    lifespan: TechEvolutionIndicator
+    line_or_link: Literal["Line", "Link"]
+
+    @classmethod
+    def from_yaml(cls, dir_containing_tech_specs: Path, technology_name: str) -> "TransmissionTechnologySpecs":
+        with open(f"{dir_containing_tech_specs}/tech_specs/{technology_name}.yaml") as file:
+            data = yaml.safe_load(file)
+
+        return cls(
+            technology_name=technology_name,
+            reactance=TechEvolutionIndicator(**data["reactance"]),
+            capacity=TechEvolutionIndicator(**data["capacity"]),
+            capital_cost_per_mw=TechEvolutionIndicator(**data["capital_cost_per_mw"]),
+            fixed_cost=TechEvolutionIndicator(**data["fixed_cost"]),
+            lifespan=TechEvolutionIndicator(**data["lifespan"]),
+            line_or_link=data["line_or_link"],
+        )

--- a/back_end/src/new_game/transmission/transmission_maker.py
+++ b/back_end/src/new_game/transmission/transmission_maker.py
@@ -1,0 +1,56 @@
+import math
+import os
+from pathlib import Path
+
+from src.models.ids import BusId, PlayerId, Round, TransmissionId
+from src.models.transmission import TransmissionInfo
+from src.new_game.transmission.tranmission_technology_specs import TransmissionTechnologySpecs
+from src.tools.random_choice import random_choice
+
+
+class TransmissionMaker:
+    path = Path(os.path.dirname(__file__))
+
+    @classmethod
+    def make_one(cls, transmission_id: TransmissionId, bus1: BusId, bus2: BusId, current_round: Round, technology_name: str | None = None, player_id: PlayerId = PlayerId.get_npc()) -> TransmissionInfo:
+        """Create a load with properties based on the current round."""
+        available_techs = cls.get_available_technologies()
+        technology_name = random_choice(available_techs)
+
+        tech_specs = cls._get_technology_spec(technology_name)
+
+        reactance = tech_specs.reactance.value_at_round(current_round)
+        capacity = tech_specs.capacity.value_at_round(current_round)
+        health = math.floor(tech_specs.lifespan.value_at_round(current_round))
+
+        foc = tech_specs.fixed_cost.value_at_round(current_round)
+        capital_cost = round(tech_specs.capital_cost_per_mw.value_at_round(current_round) * capacity)
+
+        line_or_link = tech_specs.line_or_link
+
+        return TransmissionInfo(
+            id=transmission_id,
+            owner_player=player_id,
+            bus1=bus1,
+            bus2=bus2,
+            reactance=reactance,
+            capacity=capacity,
+            health=health,
+            fixed_operating_cost=foc,
+            is_for_sale=True if player_id == PlayerId.get_npc() else False,
+            minimum_acquisition_price=capital_cost,
+            is_active=True,
+            birthday=current_round,
+            line_or_link=line_or_link
+        )
+
+    @classmethod
+    def get_available_technologies(cls) -> list[str]:
+        tech_specs_dir = TransmissionMaker.path / "tech_specs"
+        yaml_files = tech_specs_dir.rglob("*.yaml")
+        return [f.stem for f in yaml_files]
+
+    @classmethod
+    def _get_technology_spec(cls, technology_name: str) -> TransmissionTechnologySpecs:
+        assert technology_name in cls.get_available_technologies(), f"Technology not available, select from: {cls.get_available_technologies()}."
+        return TransmissionTechnologySpecs.from_yaml(TransmissionMaker.path, technology_name)

--- a/back_end/src/new_game/util/technology_specs.py
+++ b/back_end/src/new_game/util/technology_specs.py
@@ -11,6 +11,7 @@ class TechEvolutionIndicator:
     change_per_round: float
     max: float
     min: float
+    random_band_pu: float = 0.0
 
     def __post_init__(self):
         assert self.min <= self.base <= self.max, "Base value must be within min and max bounds."
@@ -18,7 +19,12 @@ class TechEvolutionIndicator:
     def value_at_round(self, round_number: int) -> float:
         """Linear function with clipping at min and max"""
         val = self.base + self.change_per_round * round_number
+        val = self.add_noise(val)
         return float(np.clip(val, self.min, self.max))
+
+    def add_noise(self, val: float) -> float:
+        rng = np.random.default_rng()
+        return val * (1 + rng.uniform(-self.random_band_pu, self.random_band_pu))
 
 
 @dataclass(frozen=True)

--- a/back_end/tests/test_engine/test_market_coupling.py
+++ b/back_end/tests/test_engine/test_market_coupling.py
@@ -138,7 +138,7 @@ class TestMarketCoupling(BaseTest):
                 if not transmission.is_active:
                     continue
                 elif np.isclose(abs(flow), abs(transmission.capacity)):
-                    self.assertGreater(
+                    self.assertGreaterEqual(
                         abs(market_result.bus_prices.loc[mtu, transmission.bus1] - market_result.bus_prices.loc[mtu, transmission.bus2]),
                         0,
                     )

--- a/back_end/tests/test_engine/test_market_coupling.py
+++ b/back_end/tests/test_engine/test_market_coupling.py
@@ -24,6 +24,7 @@ class TestMarketCoupling(BaseTest):
 
         transmission_maker = TransmissionRepoMaker(players=player_repo.human_player_ids, buses=bus_repo)
         transmission_maker.add_transmission(is_active=False)
+        transmission_maker.add_transmission(line_or_link="Link")
         transmission_maker.add_n_random(1)
 
         # add generators

--- a/back_end/tests/test_engine/test_referee.py
+++ b/back_end/tests/test_engine/test_referee.py
@@ -5,7 +5,7 @@ from src.models.market_coupling_result import MarketCouplingResult
 from src.models.message import IceCreamMeltedMessage
 from tests.base_test import BaseTest
 from tests.utils.game_state_maker import GameStateMaker, MarketResultMaker
-from tests.utils.repo_maker import AssetRepoMaker, BusRepoMaker, PlayerRepoMaker
+from tests.utils.repo_maker import AssetRepoMaker, BusRepoMaker, PlayerRepoMaker, TransmissionRepoMaker
 
 
 class TestReferee(BaseTest):
@@ -16,9 +16,11 @@ class TestReferee(BaseTest):
         player_repo = PlayerRepoMaker.make_quick(n=max(3, n_melted))
         buses = BusRepoMaker.make_quick(n_npc_buses=3, players=player_repo)
         asset_maker = AssetRepoMaker(bus_repo=buses, players=player_repo)
+        transmission_maker = TransmissionRepoMaker(players=player_repo, buses=buses)
 
         for _ in range(6):
             asset_maker.add_asset(cat="Generator", power_std=0, is_for_sale=True)
+            transmission_maker.add_transmission(is_for_sale=True)
 
         assets = asset_maker.make()
         game_state = game_maker.add_bus_repo(buses).add_asset_repo(assets).make()

--- a/back_end/tests/test_engine/test_transmission_maker.py
+++ b/back_end/tests/test_engine/test_transmission_maker.py
@@ -13,5 +13,5 @@ class TestTransmissionMaker(BaseTest):
     def test_available_technologies(self):
         technologies = TransmissionMaker.get_available_technologies()
 
-        for tech in ["AC", "DC"]:
+        for tech in ["ac", "dc"]:
             self.assertIn(tech, technologies)

--- a/back_end/tests/test_engine/test_transmission_maker.py
+++ b/back_end/tests/test_engine/test_transmission_maker.py
@@ -1,0 +1,17 @@
+from src.models.ids import TransmissionId, BusId, PlayerId, Round
+from src.models.transmission import TransmissionInfo
+from src.new_game.transmission.transmission_maker import TransmissionMaker
+from tests.base_test import BaseTest
+
+
+class TestTransmissionMaker(BaseTest):
+    def test_make_transmission(self):
+        transmission = TransmissionMaker.make_one(technology_name="AC", transmission_id=TransmissionId(1), bus1=BusId(1), bus2=BusId(2), current_round=Round(0), player_id=PlayerId.get_npc())
+
+        self.assertIsInstance(transmission, TransmissionInfo)
+
+    def test_available_technologies(self):
+        technologies = TransmissionMaker.get_available_technologies()
+
+        for tech in ["AC", "DC"]:
+            self.assertIn(tech, technologies)

--- a/back_end/tests/utils/repo_maker.py
+++ b/back_end/tests/utils/repo_maker.py
@@ -355,6 +355,7 @@ class TransmissionRepoMaker(RepoMaker[TransmissionRepo, TransmissionInfo]):
         is_for_sale: bool | None = None,
         minimum_acquisition_price: float | None = None,
         is_active: bool | None = None,
+        line_or_link: str | None = None,
     ) -> Self:
         if transmission_info is None:
             transmission = self._make_dc(
@@ -367,6 +368,7 @@ class TransmissionRepoMaker(RepoMaker[TransmissionRepo, TransmissionInfo]):
                 is_for_sale=is_for_sale,
                 minimum_acquisition_price=minimum_acquisition_price,
                 is_active=is_active,
+                line_or_link=line_or_link,
             )
 
         self._safe_append(transmission)
@@ -399,6 +401,7 @@ class TransmissionRepoMaker(RepoMaker[TransmissionRepo, TransmissionInfo]):
         is_for_sale: bool | None = None,
         minimum_acquisition_price: float | None = None,
         is_active: bool | None = None,
+        line_or_link: str | None = None,
     ) -> TransmissionInfo:
         transmission_id = TransmissionId(next(self.id_counter))
         if owner is None:
@@ -422,6 +425,7 @@ class TransmissionRepoMaker(RepoMaker[TransmissionRepo, TransmissionInfo]):
             is_for_sale=is_for_sale if is_for_sale is not None else random_choice([True, False]),
             minimum_acquisition_price=(minimum_acquisition_price if minimum_acquisition_price is not None else float(np.random.rand() * 1000) if random_choice([True, False]) else 0.0),
             is_active=is_active if is_active is not None else True,
+            line_or_link=line_or_link if line_or_link is not None else "Line",
         )
 
     def _get_repo_type(self) -> type[TransmissionRepo]:

--- a/front_end/src/components/Game/TransmissionLine.tsx
+++ b/front_end/src/components/Game/TransmissionLine.tsx
@@ -71,6 +71,7 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
         `$${line.minimum_acquisition_price.toLocaleString()}`;
     }
 
+    data["Supply Mode"] = line.line_or_link === "Line" ? "AC" : "DC";
     data["Status"] = displayActive ? "CLOSED" : "OPEN";
 
     return data;

--- a/front_end/src/types/game.ts
+++ b/front_end/src/types/game.ts
@@ -30,6 +30,7 @@ export interface TransmissionLine {
   is_active: boolean;
   is_open: boolean;
   birthday: number;
+  line_or_link: string;
   color: string;
 }
 


### PR DESCRIPTION
Implemented TransmissionMaker to enable determining tech specificaitons and spawning new transmission.

Included support for DC links. Now AC, DC and hybrid grids are possible in the game. DC grids can be easier to understand since they don't follow power transfer distribution rules. 