### PR TITLE
Hf 92 dc and ac lines should look different from each other

### DIFF
--- a/front_end/src/components/Game/TransmissionLine.tsx
+++ b/front_end/src/components/Game/TransmissionLine.tsx
@@ -193,8 +193,8 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
   const perpAngle = lineAngle + Math.PI / 2; // Perpendicular angle
   const perpVector: Point = { x: Math.cos(perpAngle), y: Math.sin(perpAngle) };
 
-  // Add slight curve by offsetting the middle point
-  const curveOffset = 0.1;
+  // For AC lines: Add slight curve by offsetting the middle point; For DC links, do not add the curve.
+  const curveOffset = line.line_or_link === "Line" ? 0.25 : 0.0;
   const offsetX = baseVector.y * curveOffset;
   const offsetY = -baseVector.x * curveOffset;
 

--- a/front_end/src/components/Game/TransmissionLine.tsx
+++ b/front_end/src/components/Game/TransmissionLine.tsx
@@ -8,6 +8,7 @@ import {
   TransmissionLine,
 } from "@/types/game";
 import React from "react";
+import { formatNumber } from "./utils";
 
 interface TransmissionLineProps {
   line: TransmissionLine;
@@ -71,6 +72,9 @@ const TransmissionLineComponent: React.FC<TransmissionLineProps> = ({
     }
 
     data["Supply Mode"] = line.line_or_link === "Line" ? "AC" : "DC";
+    data["Capacity"] = `${formatNumber(line.capacity, 1)} MW`;
+    data["Connects"] = `Bus${line.bus1} - Bus${line.bus2}`;
+    data["Reactance"] = `${formatNumber(line.reactance, 1)} Ω`;
     data["Status"] = displayActive ? "CLOSED" : "OPEN";
 
     return data;


### PR DESCRIPTION
Subtle difference between lines and links. Lines are curved, links are straight. 
In this way, players can quickly see the technology without having to hover. 

Also added some additional parameters for transmission elements in their info tables.